### PR TITLE
fix: 修复 semantic-release 推送权限问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -93,5 +94,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: pnpm semantic-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+# [1.1.0-develop.3](https://github.com/steveoon/agent-computer-user/compare/v1.1.0-develop.2...v1.1.0-develop.3) (2025-08-08)
+
+
+### Bug Fixes
+
+* 修复 semantic-release 无法推送到受保护分支的问题 ([a60d2de](https://github.com/steveoon/agent-computer-user/commit/a60d2de09f1bf66cb97c82663140c4f0d313f600))
+
 # [1.1.0-develop.2](https://github.com/steveoon/agent-computer-user/compare/v1.1.0-develop.1...v1.1.0-develop.2) (2025-08-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.1.0-develop.2",
+  "version": "1.1.0-develop.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## 修复内容

修复了 semantic-release 无法推送到受保护的 main 分支的问题。

## 更改详情

- 🔧 使用 `RELEASE_TOKEN` (Personal Access Token) 替代默认的 `GITHUB_TOKEN`
- 🔧 添加 `persist-credentials: true` 确保凭据在整个 workflow 中持久化
- 🔧 这样 semantic-release 可以绕过 main 分支的保护规则进行版本发布

## 测试计划

- [x] 已配置 RELEASE_TOKEN 到仓库 Secrets
- [ ] 合并后验证 Release workflow 能够成功运行
- [ ] 确认能够自动创建 tag 和发布 changelog

## 相关 Issue

解决了之前 PR #8 合并时 Release job 失败的问题（错误：GH013 Repository rule violations）

🤖 Generated with [Claude Code](https://claude.ai/code)