### PR TITLE
feat: 实现 GET /api/v1/models API 端点

### DIFF
--- a/.history/lib/tools/tool-registry_20250917140737.ts
+++ b/.history/lib/tools/tool-registry_20250917140737.ts
@@ -1,0 +1,523 @@
+/**
+ * 工具注册表系统
+ * 集中管理所有AI工具的创建、注册和过滤
+ */
+
+import { bashTool, computerTool } from "@/lib/e2b/tool";
+import { feishuBotTool } from "./feishu-bot-tool";
+import { puppeteerTool } from "./puppeteer-tool";
+import { analyzeScreenshotTool } from "./analyze-screenshot.tool";
+import { weChatBotTool } from "./wechat-bot-tool";
+import { jobPostingGeneratorTool } from "./job-posting-generator-tool";
+import { zhipinReplyTool } from "./zhipin-reply-tool";
+import { zhipinTools } from "./zhipin";
+import { yupaoTools } from "./yupao";
+import { dulidayJobListTool } from "./duliday/duliday-job-list-tool";
+import { dulidayJobDetailsTool } from "./duliday/duliday-job-details-tool";
+import { dulidayInterviewBookingTool } from "./duliday/duliday-interview-booking-tool";
+import { dulidayBiReportTool } from "./duliday/bi-report-tool";
+import { dulidayBiRefreshTool } from "./duliday/bi-refresh-tool";
+import { DEFAULT_MODEL_CONFIG } from "@/lib/config/models";
+
+// Import types from centralized location
+import type {
+  ToolCreationContext,
+  ToolDefinition,
+  ToolCategory,
+  SystemPromptType,
+  ToolSet,
+} from "@/types/tool-common";
+import { safeCreateTool, createToolDefinition } from "@/types/tool-common";
+
+// ========== 工具注册表 ==========
+
+/**
+ * 工具注册表
+ * 所有工具的定义都在这里，使用类型安全的定义
+ * Note: 使用 ToolDefinition 而不指定泛型，允许工具有各自的输入输出类型
+ */
+const TOOL_REGISTRY: Record<string, ToolDefinition> = {
+  // ===== 沙盒工具 =====
+  computer: createToolDefinition({
+    name: "computer",
+    description: "E2B沙盒中的计算机控制工具",
+    category: "sandbox",
+    requiresSandbox: true,
+    requiredContext: ["sandboxId"],
+    create: ctx => {
+      // 只有当 sandboxId 存在时才创建
+      if (!ctx.sandboxId) return null;
+      return computerTool(
+        ctx.sandboxId,
+        ctx.preferredBrand || "",
+        ctx.modelConfig || DEFAULT_MODEL_CONFIG,
+        ctx.configData,
+        ctx.replyPrompts,
+        ctx.defaultWechatId
+      );
+    },
+  }),
+
+  // ===== 通用工具 =====
+  bash: createToolDefinition({
+    name: "bash",
+    description: "Bash命令执行工具",
+    category: "universal",
+    requiresSandbox: false,
+    create: ctx => bashTool(ctx.sandboxId || undefined),
+  }),
+
+  // ===== 通信工具 =====
+  feishu: {
+    name: "feishu",
+    description: "飞书机器人消息工具",
+    category: "communication",
+    requiresSandbox: false,
+    create: () => feishuBotTool(),
+  },
+
+  wechat: {
+    name: "wechat",
+    description: "微信机器人消息工具",
+    category: "communication",
+    requiresSandbox: false,
+    create: () => weChatBotTool(),
+  },
+
+  // ===== 业务工具 =====
+  job_posting_generator: {
+    name: "job_posting_generator",
+    description: "职位发布生成器",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => jobPostingGeneratorTool(ctx.preferredBrand, ctx.configData),
+  },
+
+  zhipin_reply_generator: {
+    name: "zhipin_reply_generator",
+    description: "智聘智能回复生成器",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx =>
+      zhipinReplyTool(
+        ctx.preferredBrand,
+        ctx.modelConfig || DEFAULT_MODEL_CONFIG,
+        ctx.configData,
+        ctx.replyPrompts,
+        ctx.defaultWechatId
+      ),
+  },
+
+  // ===== 自动化工具 =====
+  puppeteer: {
+    name: "puppeteer",
+    description: "Puppeteer浏览器自动化工具",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => puppeteerTool(),
+  },
+
+  analyze_screenshot: {
+    name: "analyze_screenshot",
+    description: "截图分析工具，使用AI分析截图内容",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => analyzeScreenshotTool(),
+  },
+
+  // ===== Zhipin 自动化工具 =====
+  zhipin_get_unread_candidates_improved: {
+    name: "zhipin_get_unread_candidates_improved",
+    description: "获取智聘未读候选人",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getUnreadCandidatesImproved,
+  },
+
+  zhipin_open_candidate_chat_improved: {
+    name: "zhipin_open_candidate_chat_improved",
+    description: "打开智聘候选人聊天",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.openCandidateChatImproved,
+  },
+
+  zhipin_send_message: {
+    name: "zhipin_send_message",
+    description: "发送智聘消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.sendMessage(),
+  },
+
+  zhipin_get_chat_details: {
+    name: "zhipin_get_chat_details",
+    description: "获取智聘聊天详情",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getChatDetails(),
+  },
+
+  zhipin_exchange_wechat: {
+    name: "zhipin_exchange_wechat",
+    description: "交换微信",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.exchangeWechat(),
+  },
+
+  zhipin_get_username: {
+    name: "zhipin_get_username",
+    description: "获取智聘用户名",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getUsername,
+  },
+
+  zhipin_say_hello: {
+    name: "zhipin_say_hello",
+    description: "Boss直聘批量打招呼",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.sayHelloSimple(),
+  },
+
+  zhipin_get_candidate_list: {
+    name: "zhipin_get_candidate_list",
+    description: "获取Boss直聘候选人列表",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getCandidateList(),
+  },
+
+  zhipin_open_resume: {
+    name: "zhipin_open_resume",
+    description: "打开Boss直聘候选人简历",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.openResume(),
+  },
+
+  zhipin_locate_resume_canvas: {
+    name: "zhipin_locate_resume_canvas",
+    description: "定位Boss直聘简历Canvas位置",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.locateResumeCanvas(),
+  },
+
+  zhipin_close_resume_detail: {
+    name: "zhipin_close_resume_detail",
+    description: "关闭Boss直聘简历详情弹窗",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.closeResumeDetail(),
+  },
+
+  // ===== Yupao 自动化工具 =====
+  yupao_get_unread_messages: {
+    name: "yupao_get_unread_messages",
+    description: "获取约聘未读消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getUnreadMessages,
+  },
+
+  yupao_open_candidate_chat: {
+    name: "yupao_open_candidate_chat",
+    description: "打开约聘候选人聊天",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.openCandidateChat,
+  },
+
+  yupao_get_chat_details: {
+    name: "yupao_get_chat_details",
+    description: "获取约聘聊天详情",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getChatDetails,
+  },
+
+  yupao_send_message: {
+    name: "yupao_send_message",
+    description: "发送约聘消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.sendMessage,
+  },
+
+  yupao_exchange_wechat: {
+    name: "yupao_exchange_wechat",
+    description: "约聘交换微信",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.exchangeWechat,
+  },
+
+  yupao_get_username: {
+    name: "yupao_get_username",
+    description: "获取约聘用户名",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getUsername,
+  },
+
+  yupao_get_candidate_list: {
+    name: "yupao_get_candidate_list",
+    description: "获取约聘候选人列表",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getCandidateList,
+  },
+
+  yupao_say_hello: {
+    name: "yupao_say_hello",
+    description: "约聘批量打招呼",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.sayHello,
+  },
+
+  // ===== Duliday 业务工具 =====
+  duliday_job_list: {
+    name: "duliday_job_list",
+    description: "Duliday职位列表",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayJobListTool(ctx.dulidayToken, ctx.preferredBrand),
+  },
+
+  duliday_job_details: {
+    name: "duliday_job_details",
+    description: "Duliday职位详情",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayJobDetailsTool(ctx.dulidayToken),
+  },
+
+  duliday_interview_booking: {
+    name: "duliday_interview_booking",
+    description: "Duliday面试预约",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayInterviewBookingTool(ctx.dulidayToken),
+  },
+
+  duliday_bi_report: {
+    name: "duliday_bi_report",
+    description: "Duliday BI报表",
+    category: "business",
+    requiresSandbox: false,
+    create: () => dulidayBiReportTool(),
+  },
+
+  duliday_bi_refresh: {
+    name: "duliday_bi_refresh",
+    description: "Duliday BI刷新",
+    category: "business",
+    requiresSandbox: false,
+    create: () => dulidayBiRefreshTool(),
+  },
+};
+
+// ========== 工具分组配置 ==========
+
+/**
+ * 根据系统提示词定义可用的工具
+ */
+const PROMPT_TOOL_MAPPING: Record<string, string[]> = {
+  // Boss直聘E2B版 - 使用E2B桌面自动化
+  bossZhipinSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 沙盒工具
+    "computer",
+    // 业务工具
+    "job_posting_generator",
+    "zhipin_reply_generator",
+    "duliday_job_list",
+    "duliday_job_details",
+    "duliday_interview_booking",
+    "duliday_bi_report",
+    "duliday_bi_refresh",
+  ],
+
+  // Boss直聘本地版 - 使用Puppeteer自动化
+  bossZhipinLocalSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 自动化工具
+    "puppeteer",
+    "analyze_screenshot",
+    // 业务工具
+    "job_posting_generator",
+    "zhipin_reply_generator",
+    "duliday_job_list",
+    "duliday_job_details",
+    "duliday_interview_booking",
+    "duliday_bi_report",
+    "duliday_bi_refresh",
+    // Zhipin自动化
+    "zhipin_get_unread_candidates_improved",
+    "zhipin_open_candidate_chat_improved",
+    "zhipin_send_message",
+    "zhipin_get_chat_details",
+    "zhipin_exchange_wechat",
+    "zhipin_get_username",
+    "zhipin_say_hello",
+    "zhipin_get_candidate_list",
+    "zhipin_open_resume",
+    "zhipin_locate_resume_canvas",
+    "zhipin_close_resume_detail",
+    // Yupao自动化
+    "yupao_get_unread_messages",
+    "yupao_open_candidate_chat",
+    "yupao_get_chat_details",
+    "yupao_send_message",
+    "yupao_exchange_wechat",
+    "yupao_get_username",
+    "yupao_get_candidate_list",
+    "yupao_say_hello",
+  ],
+
+  // 通用计算机使用 - 包含E2B和Puppeteer，但不包含Boss直聘业务工具
+  generalComputerSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 沙盒工具
+    "computer",
+    // 自动化工具
+    "puppeteer",
+    "analyze_screenshot",
+  ],
+};
+
+// ========== 工具管理器核心功能 ==========
+
+/**
+ * 创建并获取所有工具
+ * 这是主要的入口函数，使用类型安全的工具创建
+ */
+export function createTools(context: ToolCreationContext): ToolSet {
+  const tools: ToolSet = {};
+
+  // 遍历注册表，创建所有工具
+  for (const [toolName, definition] of Object.entries(TOOL_REGISTRY)) {
+    // 使用类型安全的创建包装器
+    const tool = safeCreateTool(definition, context);
+    if (tool !== null) {
+      tools[toolName] = tool;
+    }
+  }
+
+  console.log(`🔧 创建了 ${Object.keys(tools).length} 个工具`);
+  return tools;
+}
+
+/**
+ * 根据系统提示词过滤工具
+ */
+export function filterToolsBySystemPrompt(
+  allTools: ToolSet,
+  activeSystemPrompt: SystemPromptType
+): ToolSet {
+  // 获取允许的工具列表
+  const allowedTools = PROMPT_TOOL_MAPPING[activeSystemPrompt];
+
+  // 如果没有找到对应的映射，返回所有工具（兼容性处理）
+  if (!allowedTools) {
+    console.warn(`⚠️ 未找到系统提示词 "${activeSystemPrompt}" 的工具映射，返回所有工具`);
+    return allTools;
+  }
+
+  // 过滤工具
+  const filteredTools: ToolSet = {};
+
+  for (const [toolName, tool] of Object.entries(allTools)) {
+    if (allowedTools.includes(toolName)) {
+      filteredTools[toolName] = tool;
+    }
+  }
+
+  // 记录过滤结果
+  const originalCount = Object.keys(allTools).length;
+  const filteredCount = Object.keys(filteredTools).length;
+  console.log(
+    `🔧 工具过滤: ${activeSystemPrompt} - 从 ${originalCount} 个工具过滤为 ${filteredCount} 个工具`
+  );
+  console.log(`✅ 可用工具: ${Object.keys(filteredTools).join(", ")}`);
+
+  return filteredTools;
+}
+
+/**
+ * 创建并过滤工具（一步到位）
+ * 这是最简洁的API，用于替代route.ts中的复杂逻辑
+ */
+export function createAndFilterTools(
+  context: ToolCreationContext,
+  promptType: SystemPromptType
+): ToolSet {
+  const allTools = createTools(context);
+  return filterToolsBySystemPrompt(allTools, promptType);
+}
+
+// ========== 工具信息和调试功能 ==========
+
+/**
+ * 获取所有注册的工具名称
+ */
+export function getAllToolNames(): string[] {
+  return Object.keys(TOOL_REGISTRY);
+}
+
+/**
+ * 获取指定类别的工具
+ */
+export function getToolsByCategory(category: ToolCategory): string[] {
+  return Object.entries(TOOL_REGISTRY)
+    .filter(([_, def]) => def.category === category)
+    .map(([name]) => name);
+}
+
+/**
+ * 获取需要沙盒的工具
+ */
+export function getSandboxRequiredTools(): string[] {
+  return Object.entries(TOOL_REGISTRY)
+    .filter(([_, def]) => def.requiresSandbox)
+    .map(([name]) => name);
+}
+
+/**
+ * 检查某个工具是否在指定提示词下可用
+ */
+export function isToolAllowed(toolName: string, activeSystemPrompt: SystemPromptType): boolean {
+  const allowedTools = PROMPT_TOOL_MAPPING[activeSystemPrompt];
+  return allowedTools ? allowedTools.includes(toolName) : true;
+}
+
+/**
+ * 获取系统提示词对应的工具列表
+ */
+export function getToolsForPrompt(promptType: SystemPromptType): string[] {
+  return PROMPT_TOOL_MAPPING[promptType] || [];
+}
+
+// ========== 导出其他功能函数 ==========
+
+// 为了向后兼容，重新导出类型
+export type {
+  ToolCreationContext,
+  ToolDefinition,
+  ToolCategory,
+  SystemPromptType,
+  ToolSet,
+} from "@/types/tool-common";

--- a/.history/lib/tools/tool-registry_20250923100442.ts
+++ b/.history/lib/tools/tool-registry_20250923100442.ts
@@ -1,0 +1,523 @@
+/**
+ * 工具注册表系统
+ * 集中管理所有AI工具的创建、注册和过滤
+ */
+
+import { bashTool, computerTool } from "@/lib/e2b/tool";
+import { feishuBotTool } from "./feishu-bot-tool";
+import { puppeteerTool } from "./puppeteer-tool";
+import { analyzeScreenshotTool } from "./analyze-screenshot.tool";
+import { weChatBotTool } from "./wechat-bot-tool";
+import { jobPostingGeneratorTool } from "./job-posting-generator-tool";
+import { zhipinReplyTool } from "./zhipin-reply-tool";
+import { zhipinTools } from "./zhipin";
+import { yupaoTools } from "./yupao";
+import { dulidayJobListTool } from "./duliday/duliday-job-list-tool";
+import { dulidayJobDetailsTool } from "./duliday/duliday-job-details-tool";
+import { dulidayInterviewBookingTool } from "./duliday/duliday-interview-booking-tool";
+import { dulidayBiReportTool } from "./duliday/bi-report-tool";
+import { dulidayBiRefreshTool } from "./duliday/bi-refresh-tool";
+import { DEFAULT_MODEL_CONFIG } from "@/lib/config/models";
+
+// Import types from centralized location
+import type {
+  ToolCreationContext,
+  ToolDefinition,
+  ToolCategory,
+  SystemPromptType,
+  ToolSet,
+} from "@/types/tool-common";
+import { safeCreateTool, createToolDefinition } from "@/types/tool-common";
+
+// ========== 工具注册表 ==========
+
+/**
+ * 工具注册表
+ * 所有工具的定义都在这里，使用类型安全的定义
+ * Note: 使用 ToolDefinition 而不指定泛型，允许工具有各自的输入输出类型
+ */
+const TOOL_REGISTRY: Record<string, ToolDefinition> = {
+  // ===== 沙盒工具 =====
+  computer: createToolDefinition({
+    name: "computer",
+    description: "E2B沙盒中的计算机控制工具",
+    category: "sandbox",
+    requiresSandbox: true,
+    requiredContext: ["sandboxId"],
+    create: ctx => {
+      // 只有当 sandboxId 存在时才创建
+      if (!ctx.sandboxId) return null;
+      return computerTool(
+        ctx.sandboxId,
+        ctx.preferredBrand || "",
+        ctx.modelConfig || DEFAULT_MODEL_CONFIG,
+        ctx.configData,
+        ctx.replyPrompts,
+        ctx.defaultWechatId
+      );
+    },
+  }),
+
+  // ===== 通用工具 =====
+  bash: createToolDefinition({
+    name: "bash",
+    description: "Bash命令执行工具",
+    category: "universal",
+    requiresSandbox: false,
+    create: ctx => bashTool(ctx.sandboxId || undefined),
+  }),
+
+  // ===== 通信工具 =====
+  feishu: {
+    name: "feishu",
+    description: "飞书机器人消息工具",
+    category: "communication",
+    requiresSandbox: false,
+    create: () => feishuBotTool(),
+  },
+
+  wechat: {
+    name: "wechat",
+    description: "微信机器人消息工具",
+    category: "communication",
+    requiresSandbox: false,
+    create: () => weChatBotTool(),
+  },
+
+  // ===== 业务工具 =====
+  job_posting_generator: {
+    name: "job_posting_generator",
+    description: "职位发布生成器",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => jobPostingGeneratorTool(ctx.preferredBrand, ctx.configData),
+  },
+
+  zhipin_reply_generator: {
+    name: "zhipin_reply_generator",
+    description: "智聘智能回复生成器",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx =>
+      zhipinReplyTool(
+        ctx.preferredBrand,
+        ctx.modelConfig || DEFAULT_MODEL_CONFIG,
+        ctx.configData,
+        ctx.replyPrompts,
+        ctx.defaultWechatId
+      ),
+  },
+
+  // ===== 自动化工具 =====
+  puppeteer: {
+    name: "puppeteer",
+    description: "Puppeteer浏览器自动化工具",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => puppeteerTool(),
+  },
+
+  analyze_screenshot: {
+    name: "analyze_screenshot",
+    description: "截图分析工具，使用AI分析截图内容",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => analyzeScreenshotTool(),
+  },
+
+  // ===== Zhipin 自动化工具 =====
+  zhipin_get_unread_candidates_improved: {
+    name: "zhipin_get_unread_candidates_improved",
+    description: "获取智聘未读候选人",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getUnreadCandidatesImproved,
+  },
+
+  zhipin_open_candidate_chat_improved: {
+    name: "zhipin_open_candidate_chat_improved",
+    description: "打开智聘候选人聊天",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.openCandidateChatImproved,
+  },
+
+  zhipin_send_message: {
+    name: "zhipin_send_message",
+    description: "发送智聘消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.sendMessage(),
+  },
+
+  zhipin_get_chat_details: {
+    name: "zhipin_get_chat_details",
+    description: "获取智聘聊天详情",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getChatDetails(),
+  },
+
+  zhipin_exchange_wechat: {
+    name: "zhipin_exchange_wechat",
+    description: "交换微信",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.exchangeWechat(),
+  },
+
+  zhipin_get_username: {
+    name: "zhipin_get_username",
+    description: "获取智聘用户名",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getUsername,
+  },
+
+  zhipin_say_hello: {
+    name: "zhipin_say_hello",
+    description: "Boss直聘批量打招呼",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.sayHelloSimple(),
+  },
+
+  zhipin_get_candidate_list: {
+    name: "zhipin_get_candidate_list",
+    description: "获取Boss直聘候选人列表",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.getCandidateList(),
+  },
+
+  zhipin_open_resume: {
+    name: "zhipin_open_resume",
+    description: "打开Boss直聘候选人简历",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.openResume(),
+  },
+
+  zhipin_locate_resume_canvas: {
+    name: "zhipin_locate_resume_canvas",
+    description: "定位Boss直聘简历Canvas位置",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.locateResumeCanvas(),
+  },
+
+  zhipin_close_resume_detail: {
+    name: "zhipin_close_resume_detail",
+    description: "关闭Boss直聘简历详情弹窗",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => zhipinTools.closeResumeDetail(),
+  },
+
+  // ===== Yupao 自动化工具 =====
+  yupao_get_unread_messages: {
+    name: "yupao_get_unread_messages",
+    description: "获取约聘未读消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getUnreadMessages,
+  },
+
+  yupao_open_candidate_chat: {
+    name: "yupao_open_candidate_chat",
+    description: "打开约聘候选人聊天",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.openCandidateChat,
+  },
+
+  yupao_get_chat_details: {
+    name: "yupao_get_chat_details",
+    description: "获取约聘聊天详情",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getChatDetails,
+  },
+
+  yupao_send_message: {
+    name: "yupao_send_message",
+    description: "发送约聘消息",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.sendMessage,
+  },
+
+  yupao_exchange_wechat: {
+    name: "yupao_exchange_wechat",
+    description: "约聘交换微信",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.exchangeWechat,
+  },
+
+  yupao_get_username: {
+    name: "yupao_get_username",
+    description: "获取约聘用户名",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getUsername,
+  },
+
+  yupao_get_candidate_list: {
+    name: "yupao_get_candidate_list",
+    description: "获取约聘候选人列表",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.getCandidateList,
+  },
+
+  yupao_say_hello: {
+    name: "yupao_say_hello",
+    description: "约聘批量打招呼",
+    category: "automation",
+    requiresSandbox: false,
+    create: () => yupaoTools.sayHello,
+  },
+
+  // ===== Duliday 业务工具 =====
+  duliday_job_list: {
+    name: "duliday_job_list",
+    description: "Duliday职位列表",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayJobListTool(ctx.dulidayToken, ctx.preferredBrand),
+  },
+
+  duliday_job_details: {
+    name: "duliday_job_details",
+    description: "Duliday职位详情",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayJobDetailsTool(ctx.dulidayToken),
+  },
+
+  duliday_interview_booking: {
+    name: "duliday_interview_booking",
+    description: "Duliday面试预约",
+    category: "business",
+    requiresSandbox: false,
+    create: ctx => dulidayInterviewBookingTool(ctx.dulidayToken),
+  },
+
+  duliday_bi_report: {
+    name: "duliday_bi_report",
+    description: "Duliday BI报表",
+    category: "business",
+    requiresSandbox: false,
+    create: () => dulidayBiReportTool(),
+  },
+
+  duliday_bi_refresh: {
+    name: "duliday_bi_refresh",
+    description: "Duliday BI刷新",
+    category: "business",
+    requiresSandbox: false,
+    create: () => dulidayBiRefreshTool(),
+  },
+};
+
+// ========== 工具分组配置 ==========
+
+/**
+ * 根据系统提示词定义可用的工具
+ */
+const PROMPT_TOOL_MAPPING: Record<string, string[]> = {
+  // Boss直聘E2B版 - 使用E2B桌面自动化
+  bossZhipinSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 沙盒工具
+    "computer",
+    // 业务工具
+    "job_posting_generator",
+    "zhipin_reply_generator",
+    "duliday_job_list",
+    "duliday_job_details",
+    "duliday_interview_booking",
+    "duliday_bi_report",
+    "duliday_bi_refresh",
+  ],
+
+  // Boss直聘本地版 - 使用Puppeteer自动化
+  bossZhipinLocalSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 自动化工具
+    "puppeteer",
+    "analyze_screenshot",
+    // 业务工具
+    "job_posting_generator",
+    "zhipin_reply_generator",
+    "duliday_job_list",
+    "duliday_job_details",
+    "duliday_interview_booking",
+    "duliday_bi_report",
+    "duliday_bi_refresh",
+    // Zhipin自动化
+    "zhipin_get_unread_candidates_improved",
+    "zhipin_open_candidate_chat_improved",
+    "zhipin_send_message",
+    "zhipin_get_chat_details",
+    "zhipin_exchange_wechat",
+    "zhipin_get_username",
+    "zhipin_say_hello",
+    "zhipin_get_candidate_list",
+    "zhipin_open_resume",
+    "zhipin_locate_resume_canvas",
+    "zhipin_close_resume_detail",
+    // Yupao自动化
+    "yupao_get_unread_messages",
+    "yupao_open_candidate_chat",
+    "yupao_get_chat_details",
+    "yupao_send_message",
+    "yupao_exchange_wechat",
+    "yupao_get_username",
+    "yupao_get_candidate_list",
+    "yupao_say_hello",
+  ],
+
+  // 通用计算机使用 - 包含E2B和Puppeteer，但不包含Boss直聘业务工具
+  generalComputerSystemPrompt: [
+    // 通用工具
+    "bash",
+    "feishu",
+    "wechat",
+    // 沙盒工具
+    "computer",
+    // 自动化工具
+    "puppeteer",
+    "analyze_screenshot",
+  ],
+};
+
+// ========== 工具管理器核心功能 ==========
+
+/**
+ * 创建并获取所有工具
+ * 这是主要的入口函数，使用类型安全的工具创建
+ */
+export function createTools(context: ToolCreationContext): ToolSet {
+  const tools: ToolSet = {};
+
+  // 遍历注册表，创建所有工具
+  for (const [toolName, definition] of Object.entries(TOOL_REGISTRY)) {
+    // 使用类型安全的创建包装器
+    const tool = safeCreateTool(definition, context);
+    if (tool !== null) {
+      tools[toolName] = tool;
+    }
+  }
+
+  console.log(`🔧 创建了 ${Object.keys(tools).length} 个工具`);
+  return tools;
+}
+
+/**
+ * 根据系统提示词过滤工具
+ */
+export function filterToolsBySystemPrompt(
+  allTools: ToolSet,
+  activeSystemPrompt: SystemPromptType
+): ToolSet {
+  // 获取允许的工具列表
+  const allowedTools = PROMPT_TOOL_MAPPING[activeSystemPrompt];
+
+  // 如果没有找到对应的映射，返回所有工具（兼容性处理）
+  if (!allowedTools) {
+    console.warn(`⚠️ 未找到系统提示词 "${activeSystemPrompt}" 的工具映射，返回所有工具`);
+    return allTools;
+  }
+
+  // 过滤工具
+  const filteredTools: ToolSet = {};
+
+  for (const [toolName, tool] of Object.entries(allTools)) {
+    if (allowedTools.includes(toolName)) {
+      filteredTools[toolName] = tool;
+    }
+  }
+
+  // 记录过滤结果
+  const originalCount = Object.keys(allTools).length;
+  const filteredCount = Object.keys(filteredTools).length;
+  console.log(
+    `🔧 工具过滤: ${activeSystemPrompt} - 从 ${originalCount} 个工具过滤为 ${filteredCount} 个工具`
+  );
+  console.log(`✅ 可用工具: ${Object.keys(filteredTools).join(", ")}`);
+
+  return filteredTools;
+}
+
+/**
+ * 创建并过滤工具（一步到位）
+ * 这是最简洁的API，用于替代route.ts中的复杂逻辑
+ */
+export function createAndFilterTools(
+  context: ToolCreationContext,
+  promptType: SystemPromptType
+): ToolSet {
+  const allTools = createTools(context);
+  return filterToolsBySystemPrompt(allTools, promptType);
+}
+
+// ========== 工具信息和调试功能 ==========
+
+/**
+ * 获取所有注册的工具名称
+ */
+export function getAllToolNames(): string[] {
+  return Object.keys(TOOL_REGISTRY);
+}
+
+/**
+ * 获取指定类别的工具
+ */
+export function getToolsByCategory(category: ToolCategory): string[] {
+  return Object.entries(TOOL_REGISTRY)
+    .filter(([_, def]) => def.category === category)
+    .map(([name]) => name);
+}
+
+/**
+ * 获取需要沙盒的工具
+ */
+export function getSandboxRequiredTools(): string[] {
+  return Object.entries(TOOL_REGISTRY)
+    .filter(([_, def]) => def.requiresSandbox)
+    .map(([name]) => name);
+}
+
+/**
+ * 检查某个工具是否在指定提示词下可用
+ */
+export function isToolAllowed(toolName: string, activeSystemPrompt: SystemPromptType): boolean {
+  const allowedTools = PROMPT_TOOL_MAPPING[activeSystemPrompt];
+  return allowedTools ? allowedTools.includes(toolName) : true;
+}
+
+/**
+ * 获取系统提示词对应的工具列表
+ */
+export function getToolsForPrompt(promptType: SystemPromptType): string[] {
+  return PROMPT_TOOL_MAPPING[promptType] || [];
+}
+
+// ========== 导出其他功能函数 ==========
+
+// 为了向后兼容，重新导出类型
+export type {
+  ToolCreationContext,
+  ToolDefinition,
+  ToolCategory,
+  SystemPromptType,
+  ToolSet,
+} from "@/types/tool-common";

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cSpell.words": ["Duliday", "feishu", "wechat"]
 }

--- a/app/api/v1/__tests__/models.test.ts
+++ b/app/api/v1/__tests__/models.test.ts
@@ -1,0 +1,269 @@
+/**
+ * /api/v1/models 接口测试用例
+ *
+ * 注意：根据文档规范，鉴权由 Next.js middleware 在路由前处理
+ * 业务路由接收到的请求已经通过了鉴权验证
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../models/route";
+import type { APISuccessResponse } from "@/types/api";
+import type { ModelsResponseBody, ModelInfo } from "@/types/api";
+
+// Mock 模型配置
+vi.mock("@/lib/config/models", () => ({
+  getOpenApiModels: vi.fn().mockReturnValue([
+    {
+      id: "anthropic/claude-3-7-sonnet-20250219",
+      name: "Claude 3.7 Sonnet",
+      categories: ["chat", "general"],
+    },
+    {
+      id: "qwen/qwen-max-latest",
+      name: "Qwen Max Latest",
+      categories: ["general"],
+    },
+    {
+      id: "openai/gpt-4o",
+      name: "GPT-4o",
+      categories: ["general"],
+    },
+    {
+      id: "moonshotai/kimi-k2-0905-preview",
+      name: "Kimi K2 0905 Preview",
+      categories: ["chat", "general"],
+    },
+  ]),
+}));
+
+describe("GET /api/v1/models", () => {
+  // 创建一个模拟的 GET 函数包装器，因为实际的 GET 不接受参数
+  const callGET = async () => {
+    return await GET();
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("成功场景", () => {
+    it("应该返回对外开放的模型列表", async () => {
+      // 注意：根据文档，请求到达这里时已经通过了 middleware 鉴权
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(Array.isArray(data.data.models)).toBe(true);
+
+      // 验证返回的模型包含必要字段
+      data.data.models.forEach(model => {
+        expect(model).toHaveProperty("id");
+        expect(model).toHaveProperty("name");
+        expect(model).toHaveProperty("categories");
+        expect(Array.isArray(model.categories)).toBe(true);
+      });
+    });
+
+    it("应该返回正确的模型数据", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      expect(response.status).toBe(200);
+      expect(data.data.models).toHaveLength(4);
+
+      // 验证特定模型存在
+      const modelIds = data.data.models.map(m => m.id);
+      expect(modelIds).toContain("anthropic/claude-3-7-sonnet-20250219");
+      expect(modelIds).toContain("qwen/qwen-max-latest");
+      expect(modelIds).toContain("openai/gpt-4o");
+      expect(modelIds).toContain("moonshotai/kimi-k2-0905-preview");
+    });
+
+    it("应该正确处理空模型列表", async () => {
+      const { getOpenApiModels } = await import("@/lib/config/models");
+      vi.mocked(getOpenApiModels).mockReturnValueOnce([]);
+
+      const response = await callGET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        success: true,
+        data: {
+          models: [],
+        },
+      });
+    });
+
+    it("应该包含不同类别的模型", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      expect(response.status).toBe(200);
+
+      // 验证存在 chat 类别的模型
+      const chatModels = data.data.models.filter(m => m.categories.includes("chat"));
+      expect(chatModels.length).toBeGreaterThan(0);
+
+      // 验证存在 general 类别的模型
+      const generalModels = data.data.models.filter(m => m.categories.includes("general"));
+      expect(generalModels.length).toBeGreaterThan(0);
+
+      // 验证特定模型的类别
+      const claudeModel = data.data.models.find(m => m.id === "anthropic/claude-3-7-sonnet-20250219");
+      expect(claudeModel?.categories).toEqual(["chat", "general"]);
+
+      const qwenModel = data.data.models.find(m => m.id === "qwen/qwen-max-latest");
+      expect(qwenModel?.categories).toEqual(["general"]);
+    });
+  });
+
+  describe("错误处理", () => {
+    it("应该处理内部服务器错误", async () => {
+      const { getOpenApiModels } = await import("@/lib/config/models");
+      vi.mocked(getOpenApiModels).mockImplementationOnce(() => {
+        throw new Error("Failed to load model configuration");
+      });
+
+      const response = await callGET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data).toMatchObject({
+        error: "InternalServerError",
+        message: expect.stringContaining("Failed to retrieve model list"),
+        statusCode: 500,
+        correlationId: expect.stringMatching(/^req-/),
+      });
+    });
+
+    it("应该处理未知错误", async () => {
+      const { getOpenApiModels } = await import("@/lib/config/models");
+      vi.mocked(getOpenApiModels).mockImplementationOnce(() => {
+        throw "Unexpected error type";
+      });
+
+      const response = await callGET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data).toHaveProperty("error", "InternalServerError");
+      expect(data).toHaveProperty("statusCode", 500);
+    });
+  });
+
+  describe("响应格式", () => {
+    it("应该包含正确的响应头", async () => {
+      const response = await callGET();
+
+      expect(response.headers.get("Content-Type")).toBe("application/json");
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    });
+
+    it("应该符合文档定义的响应格式", async () => {
+      const response = await callGET();
+      const data = await response.json();
+
+      // 验证顶层结构
+      expect(data).toHaveProperty("success", true);
+      expect(data).toHaveProperty("data");
+      expect(data.data).toHaveProperty("models");
+      expect(Array.isArray(data.data.models)).toBe(true);
+
+      // 验证每个模型的结构符合文档规范
+      data.data.models.forEach((model: ModelInfo) => {
+        expect(typeof model.id).toBe("string");
+        expect(typeof model.name).toBe("string");
+        expect(Array.isArray(model.categories)).toBe(true);
+
+        // categories 数组中的每个元素应该是字符串
+        model.categories.forEach(category => {
+          expect(typeof category).toBe("string");
+          expect(["chat", "general"]).toContain(category); // 验证类别是已知的类型
+        });
+
+        // id 应该遵循 provider/model 格式
+        expect(model.id).toMatch(/^[^/]+\/[^/]+/);
+      });
+    });
+
+    it("应该符合 OpenAPI 规范定义的响应格式", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      expect(response.status).toBe(200);
+
+      // 验证响应结构符合规范示例
+      expect(data).toMatchObject({
+        success: true,
+        data: {
+          models: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.stringMatching(/^[^/]+\/[^/]+/),
+              name: expect.any(String),
+              categories: expect.arrayContaining([
+                expect.stringMatching(/^(chat|general)$/),
+              ]),
+            }),
+          ]),
+        },
+      });
+
+      // 验证第一个模型的完整结构
+      if (data.data.models.length > 0) {
+        const firstModel = data.data.models[0];
+        expect(firstModel).toEqual({
+          id: expect.any(String),
+          name: expect.any(String),
+          categories: expect.any(Array),
+        });
+      }
+    });
+  });
+
+  describe("业务逻辑验证", () => {
+    it("模型ID应该唯一", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      const modelIds = data.data.models.map(m => m.id);
+      const uniqueIds = new Set(modelIds);
+
+      expect(modelIds.length).toBe(uniqueIds.size);
+    });
+
+    it("模型名称应该非空", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      data.data.models.forEach(model => {
+        expect(model.name.trim()).not.toBe("");
+        expect(model.name.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("每个模型应该至少有一个类别", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      data.data.models.forEach(model => {
+        expect(model.categories.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("应该包含来自不同提供商的模型", async () => {
+      const response = await callGET();
+      const data = await response.json() as APISuccessResponse<ModelsResponseBody>;
+
+      const providers = new Set(data.data.models.map(m => m.id.split("/")[0]));
+
+      // 验证至少有多个不同的提供商
+      expect(providers.size).toBeGreaterThan(1);
+      expect(providers).toContain("anthropic");
+      expect(providers).toContain("qwen");
+      expect(providers).toContain("openai");
+      expect(providers).toContain("moonshotai");
+    });
+  });
+});

--- a/app/api/v1/models/route.ts
+++ b/app/api/v1/models/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/v1/models
+ *
+ * 返回对外开放的模型列表
+ *
+ * 注意：鉴权由 Next.js middleware 处理，此路由接收的请求已通过验证
+ */
+
+import { getOpenApiModels } from "@/lib/config/models";
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  generateCorrelationId,
+  ApiErrorType,
+} from "@/lib/utils/api-response";
+import type { ModelsResponseBody } from "@/types/api";
+
+export async function GET() {
+  const correlationId = generateCorrelationId();
+
+  try {
+    // 获取所有对外开放的模型
+    const models = getOpenApiModels();
+
+    // 转换为API响应格式
+    const responseData: ModelsResponseBody = {
+      models: models.map(model => ({
+        id: model.id,
+        name: model.name,
+        categories: model.categories,
+      })),
+    };
+
+    // 返回成功响应，设置缓存头
+    return createSuccessResponse(responseData, {
+      correlationId,
+      headers: {
+        "Cache-Control": "public, max-age=3600", // 缓存1小时
+      },
+    });
+  } catch (error) {
+    console.error(`[${correlationId}] Failed to get model list:`, error);
+
+    // 返回标准化的错误响应
+    return createErrorResponse(ApiErrorType.InternalServerError, {
+      message: "Failed to retrieve model list",
+      details: error instanceof Error ? error.message : "Unknown error",
+      correlationId,
+    });
+  }
+}

--- a/lib/config/models.ts
+++ b/lib/config/models.ts
@@ -271,3 +271,23 @@ export const DEFAULT_MODEL_CONFIG = {
   classifyModel: "qwen/qwen-max-latest" as ModelId,
   replyModel: "qwen/qwen-plus-latest" as ModelId,
 } as const;
+
+// ========== Open API 对外开放模型 ==========
+
+/**
+ * 获取对外开放的模型列表
+ * 用于 GET /api/v1/models 接口
+ *
+ * 注意：对外开放所有内部支持的模型，保持内外一致性
+ */
+export function getOpenApiModels(): Array<{
+  id: ModelId;
+  name: string;
+  categories: ModelCategory[];
+}> {
+  return Object.entries(MODEL_DICTIONARY).map(([modelId, modelInfo]) => ({
+    id: modelId as ModelId,
+    name: modelInfo.name,
+    categories: [...modelInfo.categories], // 创建副本避免引用问题
+  }));
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -161,3 +161,22 @@ export function validateChatRequestBody(value: unknown): ChatRequestBody {
   const result = ChatRequestBodySchema.parse(value);
   return result as ChatRequestBody;
 }
+
+// ========== Models API 相关类型 ==========
+
+/**
+ * 模型信息类型
+ * 用于 GET /api/v1/models 接口
+ */
+export interface ModelInfo {
+  id: string;
+  name: string;
+  categories: string[];
+}
+
+/**
+ * Models API 响应体类型
+ */
+export interface ModelsResponseBody {
+  models: ModelInfo[];
+}


### PR DESCRIPTION
- 新增 getOpenApiModels() 函数用于获取对外开放的模型列表
- 实现 GET /api/v1/models API 路由，支持模型列表查询
- 添加 Models API 相关类型定义 (ModelInfo, ModelsResponseBody)
- 完善测试用例，覆盖成功场景、错误处理和业务逻辑验证
- 支持响应缓存优化 (1小时)
- 更新 VSCode 拼写检查配置

支持的功能：
- 返回所有对外开放的 AI 模型信息
- 包含模型 ID、名称和分类信息
- 支持多个 AI 提供商 (anthropic, qwen, openai, moonshotai 等)
- 标准化的 API 响应格式和错误处理