### PR TITLE
fix(electron): cross-platform symlink cleanup for Windows CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+## [1.30.1-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.30.0...v1.30.1-develop.1) (2026-04-08)
+
+
+### Bug Fixes
+
+* **electron:** replace Unix find with cross-platform symlink cleanup script ([4994049](https://github.com/steveoon/agent-computer-user/commit/49940493eb4a851559ab882822bd8e18b04b5b68))
+
 # [1.30.0](https://github.com/steveoon/agent-computer-user/compare/v1.29.0...v1.30.0) (2026-04-08)
 
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "db:init": "npx tsx scripts/init-brand-data.ts",
     "electron:dev": "concurrently \"next dev\" \"tsc -w -p tsconfig-electron.json\" \"wait-on http://localhost:3000 && cross-env ELECTRON_RUN_AS_NODE= NODE_ENV=development electron .\"",
     "electron:bundle-main": "pnpm exec esbuild src-electron/main.ts --bundle --platform=node --format=cjs --target=node20 --outfile=build/main.js --external:electron",
-    "electron:build": "shx rm -rf build dist && cross-env ELECTRON_BUILD=true next build && find .next/standalone -type l ! -exec test -e {} \\; -delete && shx cp -r .next/static .next/standalone/.next/ && shx mkdir -p .next/standalone/public && shx cp -r public/* .next/standalone/public/ && tsc -p tsconfig-electron.json && pnpm electron:bundle-main",
+    "electron:build": "shx rm -rf build dist && cross-env ELECTRON_BUILD=true next build && node scripts/prune-broken-symlinks.mjs .next/standalone && shx cp -r .next/static .next/standalone/.next/ && shx mkdir -p .next/standalone/public && shx cp -r public/* .next/standalone/public/ && tsc -p tsconfig-electron.json && pnpm electron:bundle-main",
     "electron:start": "cross-env ELECTRON_RUN_AS_NODE= electron .",
     "electron:pack": "pnpm electron:build && electron-builder --dir",
     "electron:dist": "pnpm electron:build && electron-builder",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.30.0",
+  "version": "1.30.1-develop.1",
   "private": true,
   "main": "build/main.js",
   "scripts": {

--- a/scripts/prune-broken-symlinks.mjs
+++ b/scripts/prune-broken-symlinks.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform script to remove broken symbolic links.
+ * Replaces Unix `find <dir> -type l ! -exec test -e {} \; -delete`
+ * which fails on Windows (find.exe is a different command).
+ *
+ * Usage: node scripts/prune-broken-symlinks.mjs <directory>
+ */
+
+import { readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+function pruneDir(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // Directory doesn't exist or can't be read — skip silently
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      try {
+        statSync(fullPath); // follows the link — throws if target is missing
+      } catch (error) {
+        if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+          try {
+            unlinkSync(fullPath);
+          } catch (unlinkError) {
+            // Link already removed by another process — ignore
+            if (
+              !(
+                unlinkError &&
+                typeof unlinkError === "object" &&
+                "code" in unlinkError &&
+                unlinkError.code === "ENOENT"
+              )
+            ) {
+              throw unlinkError;
+            }
+          }
+        } else {
+          throw error;
+        }
+      }
+    } else if (entry.isDirectory()) {
+      pruneDir(fullPath);
+    }
+  }
+}
+
+const target = process.argv[2];
+if (!target) {
+  console.error("Usage: node scripts/prune-broken-symlinks.mjs <directory>");
+  process.exit(1);
+}
+
+pruneDir(target);


### PR DESCRIPTION
## Summary

- Windows CI build 失败：`electron:build` 脚本中使用了 Unix `find` 命令清理 `.next/standalone` 下的断开符号链接，Windows 的 `find.exe` 是完全不同的命令
- 将内联命令提取为独立脚本 `scripts/prune-broken-symlinks.mjs`，跨平台工作
- 只在 `error.code === 'ENOENT'` 时删除符号链接，避免权限错误等误判

## Test plan

- [x] 脚本在 macOS 本地执行正常
- [x] 缺少参数时正确报错退出
- [x] 经 Codex review 确认递归逻辑、异常分类、edge case 处理均正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)