### PR TITLE
feat(recruitment): add Open API event ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+# [1.31.0-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.30.1...v1.31.0-develop.1) (2026-05-08)
+
+
+### Features
+
+* **recruitment:** add open api event ingestion ([dcee630](https://github.com/steveoon/agent-computer-user/commit/dcee6301e42b2193d063fe4e200ba99f1197e871))
+
 ## [1.30.1](https://github.com/steveoon/agent-computer-user/compare/v1.30.0...v1.30.1) (2026-04-08)
 
 

--- a/app/api/v1/recruitment-events/route.ts
+++ b/app/api/v1/recruitment-events/route.ts
@@ -1,0 +1,52 @@
+/**
+ * POST /api/v1/recruitment-events
+ *
+ * Open API endpoint for writing recruitment tracking events.
+ * This does not expose browser automation tools.
+ */
+
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  generateCorrelationId,
+  handleUnknownError,
+  ApiErrorType,
+} from "@/lib/utils/api-response";
+import { ErrorCode } from "@/lib/errors";
+import {
+  parseOpenApiRecruitmentEventsBody,
+  processOpenApiRecruitmentEvents,
+} from "@/lib/services/recruitment-event/open-api";
+import { getAllowedAgentIds } from "@/lib/utils/open-api-agent-auth";
+
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  const correlationId = generateCorrelationId();
+
+  try {
+    const allowedAgentIds = getAllowedAgentIds(req);
+    const body = await req.json();
+    const events = parseOpenApiRecruitmentEventsBody(body);
+    const result = await processOpenApiRecruitmentEvents(events, allowedAgentIds);
+
+    return createSuccessResponse(result, { correlationId });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: "Invalid JSON request body",
+        correlationId,
+      });
+    }
+
+    if (error && typeof error === "object" && "issues" in error) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: "Invalid request body",
+        details: error,
+        correlationId,
+      });
+    }
+
+    return handleUnknownError(error, correlationId, ErrorCode.SYSTEM_INTERNAL);
+  }
+}

--- a/app/api/v1/recruitment-stats/__tests__/routes.test.ts
+++ b/app/api/v1/recruitment-stats/__tests__/routes.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetDashboardSummary = vi.fn();
+const mockGetStatsTrend = vi.fn();
+
+vi.mock("@/lib/services/recruitment-stats/query.service", () => ({
+  queryService: {
+    getDashboardSummary: mockGetDashboardSummary,
+    getStatsTrend: mockGetStatsTrend,
+  },
+}));
+
+describe("recruitment stats Open API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDashboardSummary.mockResolvedValue({
+      current: [{ totalEvents: 1 }],
+      previous: [],
+      trend: {},
+    });
+    mockGetStatsTrend.mockResolvedValue([{ date: "2026-05-07", messagesReceived: 1 }]);
+  });
+
+  it("summary rejects unauthorized agentId", async () => {
+    const { GET } = await import("../summary/route");
+    const req = new Request("http://localhost/api/v1/recruitment-stats/summary?agentId=agent-2", {
+      headers: {
+        "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+      },
+    });
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(403);
+    expect(mockGetDashboardSummary).not.toHaveBeenCalled();
+  });
+
+  it("summary supports endDate and comma-separated jobNames", async () => {
+    const { GET } = await import("../summary/route");
+    const req = new Request(
+      "http://localhost/api/v1/recruitment-stats/summary?agentId=agent-1&days=7&endDate=2026-05-07&jobNames=A,B",
+      {
+        headers: {
+          "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+        },
+      }
+    );
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+    expect(mockGetDashboardSummary).toHaveBeenCalledWith(
+      "agent-1",
+      7,
+      expect.any(Date),
+      undefined,
+      ["A", "B"]
+    );
+  });
+
+  it("summary returns a clear message when the requested range has no data", async () => {
+    const { GET } = await import("../summary/route");
+    mockGetDashboardSummary.mockResolvedValueOnce({
+      current: [],
+      previous: [],
+      trend: {},
+    });
+    const req = new Request(
+      "http://localhost/api/v1/recruitment-stats/summary?agentId=agent-1&days=7&endDate=2026-05-07",
+      {
+        headers: {
+          "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+        },
+      }
+    );
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe("No recruitment stats found for the requested agent and date range");
+    expect(body.data.summary.current).toEqual([]);
+  });
+
+  it("trend supports repeated jobNames query params", async () => {
+    const { GET } = await import("../trend/route");
+    const req = new Request(
+      "http://localhost/api/v1/recruitment-stats/trend?agentId=agent-1&startDate=2026-05-01&endDate=2026-05-07&jobNames=A&jobNames=B",
+      {
+        headers: {
+          "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+        },
+      }
+    );
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+    expect(mockGetStatsTrend).toHaveBeenCalledWith(
+      "agent-1",
+      expect.any(Date),
+      expect.any(Date),
+      undefined,
+      ["A", "B"]
+    );
+  });
+
+  it("trend returns a clear message when the requested range has no data", async () => {
+    const { GET } = await import("../trend/route");
+    mockGetStatsTrend.mockResolvedValueOnce([]);
+    const req = new Request(
+      "http://localhost/api/v1/recruitment-stats/trend?agentId=agent-1&startDate=2026-05-01&endDate=2026-05-07",
+      {
+        headers: {
+          "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+        },
+      }
+    );
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe(
+      "No recruitment trend data found for the requested agent and date range"
+    );
+    expect(body.data.trend).toEqual([]);
+  });
+
+  it("summary rejects non-integer brandId", async () => {
+    const { GET } = await import("../summary/route");
+    const req = new Request(
+      "http://localhost/api/v1/recruitment-stats/summary?agentId=agent-1&brandId=1.5",
+      {
+        headers: {
+          "x-open-api-allowed-agent-ids": JSON.stringify(["agent-1"]),
+        },
+      }
+    );
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("brandId must be an integer");
+    expect(mockGetDashboardSummary).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/v1/recruitment-stats/_utils.ts
+++ b/app/api/v1/recruitment-stats/_utils.ts
@@ -1,0 +1,57 @@
+import {
+  createAgentForbiddenResponse,
+  getAllowedAgentIds,
+  isAgentAllowed,
+} from "@/lib/utils/open-api-agent-auth";
+import { ApiErrorType, createErrorResponse } from "@/lib/utils/api-response";
+import { parseBeijingDateString, toBeijingDayEnd } from "@/lib/utils/beijing-timezone";
+
+export function authorizeStatsAgent(req: Request, agentId: string | undefined, correlationId: string) {
+  const allowedAgentIds = getAllowedAgentIds(req);
+
+  if (!agentId) {
+    if (allowedAgentIds.includes("*")) return null;
+    return createErrorResponse(ApiErrorType.Forbidden, {
+      message: "agentId is required unless this API key can access all agents",
+      correlationId,
+    });
+  }
+
+  if (!isAgentAllowed(agentId, allowedAgentIds)) {
+    return createAgentForbiddenResponse(agentId, correlationId);
+  }
+
+  return null;
+}
+
+export function parseOptionalNumber(value: string | null, fieldName: string): number | undefined {
+  if (value === null || value === "") return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`${fieldName} must be an integer`);
+  }
+  return parsed;
+}
+
+export function parseJobNames(searchParams: URLSearchParams): string[] | undefined {
+  const values = searchParams.getAll("jobNames");
+  const normalized = values.flatMap(value => value.split(","));
+  const jobNames = normalized.map(value => value.trim()).filter(Boolean);
+  return jobNames.length > 0 ? jobNames : undefined;
+}
+
+export function parseDateParam(value: string | null, fieldName: string, endOfDay = false): Date {
+  if (!value) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? parseBeijingDateString(value)
+    : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${fieldName} must be a valid date`);
+  }
+
+  return endOfDay ? toBeijingDayEnd(date) : date;
+}

--- a/app/api/v1/recruitment-stats/summary/route.ts
+++ b/app/api/v1/recruitment-stats/summary/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/v1/recruitment-stats/summary
+ *
+ * Open API endpoint for Dashboard summary metrics.
+ */
+
+import {
+  ApiErrorType,
+  createErrorResponse,
+  createSuccessResponse,
+  generateCorrelationId,
+  handleUnknownError,
+} from "@/lib/utils/api-response";
+import { ErrorCode } from "@/lib/errors";
+import { queryService } from "@/lib/services/recruitment-stats/query.service";
+import {
+  authorizeStatsAgent,
+  parseJobNames,
+  parseOptionalNumber,
+  parseDateParam,
+} from "../_utils";
+
+export async function GET(req: Request) {
+  const correlationId = generateCorrelationId();
+
+  try {
+    const url = new URL(req.url);
+    const agentId = url.searchParams.get("agentId") || undefined;
+    const authError = authorizeStatsAgent(req, agentId, correlationId);
+    if (authError) return authError;
+
+    const daysRaw = url.searchParams.get("days");
+    const days = daysRaw ? Number(daysRaw) : 7;
+    if (!Number.isInteger(days) || days < 1 || days > 366) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: "days must be an integer between 1 and 366",
+        correlationId,
+      });
+    }
+
+    const brandId = parseOptionalNumber(url.searchParams.get("brandId"), "brandId");
+    const endDateRaw = url.searchParams.get("endDate");
+    const endDate = endDateRaw ? parseDateParam(endDateRaw, "endDate") : undefined;
+    const jobNames = parseJobNames(url.searchParams);
+
+    const summary = await queryService.getDashboardSummary(
+      agentId,
+      days,
+      endDate,
+      brandId,
+      jobNames
+    );
+
+    const message =
+      Array.isArray(summary.current) && summary.current.length === 0
+        ? "No recruitment stats found for the requested agent and date range"
+        : undefined;
+
+    return createSuccessResponse({ summary }, { correlationId, message });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message.includes("must be") || error.message.includes("is required"))
+    ) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: error.message,
+        correlationId,
+      });
+    }
+
+    return handleUnknownError(error, correlationId, ErrorCode.SYSTEM_INTERNAL);
+  }
+}

--- a/app/api/v1/recruitment-stats/trend/route.ts
+++ b/app/api/v1/recruitment-stats/trend/route.ts
@@ -1,0 +1,64 @@
+/**
+ * GET /api/v1/recruitment-stats/trend
+ *
+ * Open API endpoint for day-grain recruitment trends.
+ */
+
+import {
+  ApiErrorType,
+  createErrorResponse,
+  createSuccessResponse,
+  generateCorrelationId,
+  handleUnknownError,
+} from "@/lib/utils/api-response";
+import { ErrorCode } from "@/lib/errors";
+import { queryService } from "@/lib/services/recruitment-stats/query.service";
+import {
+  authorizeStatsAgent,
+  parseDateParam,
+  parseJobNames,
+  parseOptionalNumber,
+} from "../_utils";
+
+export async function GET(req: Request) {
+  const correlationId = generateCorrelationId();
+
+  try {
+    const url = new URL(req.url);
+    const agentId = url.searchParams.get("agentId") || undefined;
+    const authError = authorizeStatsAgent(req, agentId, correlationId);
+    if (authError) return authError;
+
+    const startDate = parseDateParam(url.searchParams.get("startDate"), "startDate");
+    const endDate = parseDateParam(url.searchParams.get("endDate"), "endDate", true);
+    if (startDate.getTime() > endDate.getTime()) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: "startDate must be before or equal to endDate",
+        correlationId,
+      });
+    }
+
+    const brandId = parseOptionalNumber(url.searchParams.get("brandId"), "brandId");
+    const jobNames = parseJobNames(url.searchParams);
+    const trend = await queryService.getStatsTrend(agentId, startDate, endDate, brandId, jobNames);
+
+    const message =
+      trend.length === 0
+        ? "No recruitment trend data found for the requested agent and date range"
+        : undefined;
+
+    return createSuccessResponse({ trend }, { correlationId, message });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message.includes("must be") || error.message.includes("is required"))
+    ) {
+      return createErrorResponse(ApiErrorType.BadRequest, {
+        message: error.message,
+        correlationId,
+      });
+    }
+
+    return handleUnknownError(error, correlationId, ErrorCode.SYSTEM_INTERNAL);
+  }
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -246,6 +246,9 @@ export const recruitmentEvents = appSchema.table(
 
     // API来源（web: 网页端, open_api: 开放接口）
     apiSource: varchar("api_source", { length: 20 }).default("web"),
+
+    // 外部调用幂等键（按 agent_id 隔离）
+    idempotencyKey: varchar("idempotency_key", { length: 128 }),
   },
   table => [
     // 查询优化索引
@@ -257,6 +260,11 @@ export const recruitmentEvents = appSchema.table(
 
     // 复合索引：支持 Dashboard 常见查询
     index("idx_re_agent_type_time").on(table.agentId, table.eventType, table.eventTime),
+
+    // 请求级幂等：只约束传入 idempotency_key 的开放接口事件
+    uniqueIndex("unique_re_idempotency")
+      .on(table.agentId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   ]
 );
 

--- a/db/types.ts
+++ b/db/types.ts
@@ -293,6 +293,7 @@ export const insertRecruitmentEventSchema = createInsertSchema(recruitmentEvents
   jobName: z.string().max(100).optional(),
   dataSource: z.string().max(20).optional(),
   apiSource: z.string().max(20).optional(),
+  idempotencyKey: z.string().max(128).optional(),
   unreadCountBeforeReply: z.number().int().optional(),
 });
 
@@ -481,6 +482,7 @@ export function createRecruitmentEventInput(params: {
   jobName?: string;
   dataSource?: DataSourceValue;
   apiSource?: ApiSourceValue;
+  idempotencyKey?: string;
 }): InsertRecruitmentEvent {
   const candidateKey = generateCandidateKey({
     platform: params.sourcePlatform || SourcePlatform.ZHIPIN,
@@ -508,5 +510,6 @@ export function createRecruitmentEventInput(params: {
     jobName: params.jobName,
     dataSource: params.dataSource || DataSource.TOOL_AUTO,
     apiSource: params.apiSource || ApiSource.WEB,
+    idempotencyKey: params.idempotencyKey,
   };
 }

--- a/docs/OPEN_API_AUTH.md
+++ b/docs/OPEN_API_AUTH.md
@@ -2,11 +2,11 @@
 
 ## 概述
 
-本项目的 Open API（`/api/v1/*`）使用外部鉴权服务进行 API Key 验证，通过 Next.js middleware 实现请求拦截和鉴权。
+本项目的 Open API（`/api/v1/*`）使用外部鉴权服务进行 API Key 验证，通过 Next.js 16 `proxy.ts` 实现请求拦截和鉴权。
 
 ## 鉴权流程
 
-1. **请求拦截**：所有 `/api/v1/*` 路径的请求都会被 middleware 拦截
+1. **请求拦截**：所有 `/api/v1/*` 路径的请求都会被 `proxy.ts` 拦截
 2. **Header 检查**：验证请求是否包含 `Authorization: Bearer <token>` 格式的认证头
 3. **缓存查询**：首先检查进程内内存缓存，如果 token 在缓存中且未过期，直接放行
 4. **外部验证**：缓存未命中时，调用外部鉴权服务进行验证
@@ -30,6 +30,10 @@ OPEN_API_AUTH_URL=https://wolian.cc/api/v1/validate-key
 - 从请求头读取 `Authorization`
 - 成功时返回 `200 OK` 和 JSON：`{"isSuccess": true, ...}`
 - 失败时返回非 2xx 状态码
+
+当前阶段暂不做 `key -> agentId` 数据范围控制。外部鉴权服务只负责判断 key 是否有效；认证通过后，`proxy.ts` 会临时注入 `allowedAgentIds: ["*"]`，业务路由允许访问任意 `agentId`。
+
+后续如果需要恢复细粒度授权，应在本项目内维护 `key -> allowedAgentIds` 映射，而不是要求 `OPEN_API_AUTH_URL` 承担业务授权逻辑。
 
 ## 缓存机制
 
@@ -61,8 +65,8 @@ OPEN_API_AUTH_URL=https://wolian.cc/api/v1/validate-key
 ### 单元测试
 
 ```bash
-# 运行 middleware 测试
-pnpm test:run __tests__/middleware.test.ts
+# 运行 proxy 测试
+pnpm test:run __tests__/proxy.test.ts
 ```
 
 ### 手动测试
@@ -121,7 +125,7 @@ OPEN_API_AUTH_URL=http://localhost:3001/api/validate-key
 
 ## 相关文件
 
-- `middleware.ts` - Middleware 实现
+- `proxy.ts` - Next.js 16 Proxy 实现（当前实际入口）
 - `lib/utils/api-response.ts` - 标准化响应工具
 - `app/api/v1/tools/route.ts` - 示例 API 端点
-- `__tests__/middleware.test.ts` - 测试文件
+- `__tests__/proxy.test.ts` - 测试文件

--- a/docs/OPEN_API_RECRUITMENT_EVENTS.md
+++ b/docs/OPEN_API_RECRUITMENT_EVENTS.md
@@ -1,0 +1,578 @@
+# Recruitment Events Open API
+
+## 结论
+
+`POST /api/v1/recruitment-events` 是统一的招聘埋点写入接口，所有 zhipin/yupao/Duliday/人工补录统计事件都通过 `eventType + details` 区分，不开放任何 `zhipin_*` 浏览器自动化工具。
+
+## 三层架构
+
+```text
+外部系统 / Bot / RPA / 后台
+  -> POST /api/v1/recruitment-events
+  -> app_huajune.recruitment_events
+  -> GET /api/v1/recruitment-stats/summary | trend
+```
+
+| 层级 | 接口 | 作用 |
+|---|---|---|
+| 写入层 | `POST /api/v1/recruitment-events` | 写入招聘事件 |
+| 汇总查询 | `GET /api/v1/recruitment-stats/summary` | 查询 Dashboard 汇总 |
+| 趋势查询 | `GET /api/v1/recruitment-stats/trend` | 查询日趋势 |
+
+## 鉴权
+
+所有 `/api/v1/*` 请求都需要：
+
+```http
+Authorization: Bearer <OPEN_API_TOKEN>
+Content-Type: application/json
+```
+
+当前阶段外部鉴权服务只负责验证 token 是否有效：
+
+```json
+{
+  "isSuccess": true,
+  "message": "验证成功"
+}
+```
+
+暂不做 `key -> agentId` 数据范围控制。认证通过后，项目会临时按 `allowedAgentIds: ["*"]` 处理，因此请求中的 `agentId` 可直接使用需要写入或查询的 Agent 标识。
+
+后续如果要做细粒度数据权限，应在本项目内维护 `key -> allowedAgentIds` 映射，而不是要求 `OPEN_API_AUTH_URL` 返回业务授权范围。
+
+## 写入端
+
+### 接口
+
+```http
+POST /api/v1/recruitment-events
+```
+
+### 通用请求结构
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "source-system-event-id",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "dataSource": "api_callback",
+      "eventType": "message_sent",
+      "eventTime": "2026-05-07T10:00:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "position": "服务员",
+        "age": "21岁",
+        "gender": "男",
+        "education": "本科",
+        "expectedSalary": "3000-4000元",
+        "expectedLocation": "上海"
+      },
+      "job": {
+        "jobId": 7,
+        "jobName": "肯德基服务员"
+      },
+      "brandId": 88,
+      "details": {}
+    }
+  ]
+}
+```
+
+### 通用字段
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `events` | 是 | 事件数组，最多 `100` 条 |
+| `idempotencyKey` | 建议 | 外部事件唯一键；同一 `agentId + idempotencyKey` 重复调用返回 `existing` |
+| `agentId` | 是 | Agent/账号标识，必须属于当前 token |
+| `sourcePlatform` | 否 | `zhipin`、`yupao`、`duliday`；默认 `zhipin` |
+| `dataSource` | 否 | `api_callback`、`manual`；默认 `api_callback` |
+| `eventType` | 是 | 事件类型，见下方事件清单 |
+| `eventTime` | 否 | ISO 时间；默认服务端当前时间 |
+| `candidate.name` | 是 | 候选人姓名 |
+| `candidate.position` | 否 | 候选人职位或沟通职位；缺省时会用 `job.jobName` 参与 `candidateKey` |
+| `job.jobId` | 否 | 外部岗位 ID |
+| `job.jobName` | 否 | 岗位名；可用于自动识别 `brandId` |
+| `brandId` | 否 | 品牌整数 ID；传入优先，否则按 `jobName` 自动识别 |
+| `details` | 按事件 | 每种 `eventType` 的事件详情 |
+
+### 返回结构
+
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "idempotencyKey": "zhipin-msg-001",
+        "status": "created",
+        "eventId": "5f4f7e0e-0000-4000-9000-000000000001",
+        "agentId": "siwen-zhipin-1",
+        "eventType": "message_sent",
+        "eventTime": "2026-05-07T02:52:00.000Z",
+        "candidateKey": "zhipin_张三_肯德基服务员",
+        "candidateName": "张三",
+        "sessionId": "siwen-zhipin-1_zhipin_张三_肯德基服务员_2026-05-07",
+        "sourcePlatform": "zhipin",
+        "jobId": 900001,
+        "jobName": "肯德基服务员",
+        "apiSource": "open_api",
+        "dataSource": "api_callback"
+      }
+    ]
+  }
+}
+```
+
+`created` 和 `existing` 都会返回同一组事件摘要字段，调用方无需再查库即可确认创建/命中的事件类型、时间、候选人和岗位。
+
+| `status` | 含义 |
+|---|---|
+| `created` | 已创建新事件 |
+| `existing` | `agentId + idempotencyKey` 已存在，返回已有事件 |
+| `error` | 单条事件失败，其他事件不回滚 |
+
+单条失败示例：
+
+```json
+{
+  "idempotencyKey": "bad-event-001",
+  "status": "error",
+  "error": {
+    "code": "InvalidEventTime",
+    "message": "eventTime cannot be more than 5 minutes in the future"
+  }
+}
+```
+
+## 事件清单
+
+### 1. `message_received`
+
+记录候选人入站消息，等价于 zhipin 工具检测到未读消息。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `message_received` |
+| `details.unreadCount` | 否 | 检测到的未读消息数 |
+| `details.lastMessagePreview` | 否 | 最后一条消息预览 |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "zhipin-unread-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "eventType": "message_received",
+      "eventTime": "2026-05-07T10:00:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "position": "肯德基服务员"
+      },
+      "job": {
+        "jobName": "肯德基服务员"
+      },
+      "details": {
+        "unreadCount": 2,
+        "lastMessagePreview": "您好，我想了解一下这个岗位"
+      }
+    }
+  ]
+}
+```
+
+### 2. `message_sent`
+
+记录我方发送消息，等价于 `zhipin_send_message` 的发送成功埋点。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `message_sent` |
+| `details.content` | 是 | 发送内容 |
+| `details.isAutoReply` | 否 | 是否自动回复 |
+| `details.unreadCountBeforeReply` | 否 | 回复前未读数；影响 `unreadReplied` 统计 |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "zhipin-send-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "eventType": "message_sent",
+      "eventTime": "2026-05-07T10:01:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "age": "21岁",
+        "education": "本科",
+        "expectedSalary": "3000-4000元",
+        "expectedLocation": "上海"
+      },
+      "job": {
+        "jobId": 7,
+        "jobName": "肯德基服务员"
+      },
+      "details": {
+        "content": "您好，可以沟通一下岗位吗？",
+        "isAutoReply": true,
+        "unreadCountBeforeReply": 2
+      }
+    }
+  ]
+}
+```
+
+### 3. `candidate_contacted`
+
+记录主动触达候选人，等价于 `zhipin_say_hello` 打招呼成功。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `candidate_contacted` |
+| `details` | 否 | 可传 `{}` |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "zhipin-hello-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "eventType": "candidate_contacted",
+      "eventTime": "2026-05-07T10:05:00+08:00",
+      "candidate": {
+        "name": "李四",
+        "position": "服务员",
+        "age": "25岁",
+        "education": "大专"
+      },
+      "job": {
+        "jobName": "麦当劳服务员"
+      },
+      "details": {}
+    }
+  ]
+}
+```
+
+### 4. `wechat_exchanged`
+
+记录微信交换。`exchangeType` 会影响转化统计口径。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `wechat_exchanged` |
+| `details.wechatNumber` | 否 | 微信号 |
+| `details.exchangeType` | 否 | `requested`、`accepted`、`completed` |
+
+`exchangeType` 语义：
+
+| 值 | 说明 | 是否计入成功交换 |
+|---|---|---:|
+| `requested` | 我方发起换微信请求，等待对方同意 | 否 |
+| `accepted` | 我方同意对方请求 | 是 |
+| `completed` | 已从聊天记录或外部回调确认完成 | 是 |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "zhipin-wechat-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "eventType": "wechat_exchanged",
+      "eventTime": "2026-05-07T10:10:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "position": "肯德基服务员"
+      },
+      "job": {
+        "jobName": "肯德基服务员"
+      },
+      "details": {
+        "wechatNumber": "wx_zhangsan",
+        "exchangeType": "completed"
+      }
+    }
+  ]
+}
+```
+
+### 5. `interview_booked`
+
+记录面试预约成功。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `interview_booked` |
+| `details.interviewTime` | 是 | 面试时间 |
+| `details.address` | 否 | 面试地址 |
+| `details.candidatePhone` | 否 | 候选人手机号 |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "duliday-interview-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "duliday",
+      "eventType": "interview_booked",
+      "eventTime": "2026-05-07T10:20:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "position": "肯德基服务员"
+      },
+      "job": {
+        "jobId": 7,
+        "jobName": "肯德基服务员"
+      },
+      "details": {
+        "interviewTime": "2026-05-08 14:00",
+        "address": "上海市浦东新区 XX 路",
+        "candidatePhone": "13800138000"
+      }
+    }
+  ]
+}
+```
+
+### 6. `candidate_hired`
+
+记录候选人上岗，通常来自人工后台补录或外部系统回调。
+
+| 字段 | 必填 | 说明 |
+|---|---:|---|
+| `eventType` | 是 | 固定 `candidate_hired` |
+| `dataSource` | 建议 | 人工补录用 `manual`，系统回调用 `api_callback` |
+| `details.hireDate` | 否 | 上岗日期 |
+| `details.notes` | 否 | 备注 |
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "manual-hired-20260507-001",
+      "agentId": "siwen-zhipin-1",
+      "sourcePlatform": "zhipin",
+      "dataSource": "manual",
+      "eventType": "candidate_hired",
+      "eventTime": "2026-05-07T11:00:00+08:00",
+      "candidate": {
+        "name": "张三",
+        "position": "肯德基服务员"
+      },
+      "job": {
+        "jobId": 7,
+        "jobName": "肯德基服务员"
+      },
+      "details": {
+        "hireDate": "2026-05-10",
+        "notes": "已确认到店上岗"
+      }
+    }
+  ]
+}
+```
+
+## 批量写入
+
+同一个请求最多 `100` 条事件。批量写入非事务，单条失败不会回滚其他条目。
+
+```json
+{
+  "events": [
+    {
+      "idempotencyKey": "batch-001",
+      "agentId": "siwen-zhipin-1",
+      "eventType": "candidate_contacted",
+      "candidate": { "name": "张三" }
+    },
+    {
+      "idempotencyKey": "batch-002",
+      "agentId": "siwen-zhipin-1",
+      "eventType": "message_received",
+      "candidate": { "name": "张三" },
+      "details": { "unreadCount": 1 }
+    }
+  ]
+}
+```
+
+## Curl 示例
+
+```bash
+curl -X POST "https://your-domain.com/api/v1/recruitment-events" \
+  -H "Authorization: Bearer $OPEN_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "events": [
+      {
+        "idempotencyKey": "zhipin-send-20260507-001",
+        "agentId": "siwen-zhipin-1",
+        "sourcePlatform": "zhipin",
+        "eventType": "message_sent",
+        "eventTime": "2026-05-07T10:01:00+08:00",
+        "candidate": { "name": "张三" },
+        "job": { "jobName": "肯德基服务员" },
+        "details": {
+          "content": "您好，可以沟通一下岗位吗？",
+          "unreadCountBeforeReply": 1
+        }
+      }
+    ]
+  }'
+```
+
+## 统计查询
+
+### 1. 汇总查询
+
+```http
+GET /api/v1/recruitment-stats/summary
+```
+
+参数：
+
+| 参数 | 必填 | 说明 |
+|---|---:|---|
+| `agentId` | 是 | 要查询的 Agent |
+| `days` | 否 | 截至 `endDate` 往前统计几天，默认 `7` |
+| `endDate` | 否 | 统计窗口结束日期；支持 `YYYY-MM-DD` 或 ISO 时间 |
+| `brandId` | 否 | 品牌整数 ID |
+| `jobNames` | 否 | 岗位名，多选支持重复参数或逗号分隔 |
+
+示例：
+
+```bash
+curl "https://your-domain.com/api/v1/recruitment-stats/summary?agentId=siwen-zhipin-1&days=7&endDate=2026-05-07&jobNames=肯德基服务员&jobNames=麦当劳服务员" \
+  -H "Authorization: Bearer $OPEN_API_TOKEN"
+```
+
+返回：
+
+```json
+{
+  "success": true,
+  "data": {
+    "summary": {
+      "current": [
+        {
+          "agentId": "siwen-zhipin-1",
+          "totalEvents": 120,
+          "messagesReceived": 35,
+          "candidatesReplied": 28,
+          "wechatExchanged": 12,
+          "interviewsBooked": 5,
+          "candidatesHired": 2
+        }
+      ],
+      "previous": [],
+      "trend": {}
+    }
+  }
+}
+```
+
+如果 `agentId + 日期范围` 下没有汇总数据，HTTP 仍返回 `200`，并带明确 `message`：
+
+```json
+{
+  "success": true,
+  "data": {
+    "summary": {
+      "current": [],
+      "previous": [],
+      "trend": {}
+    }
+  },
+  "message": "No recruitment stats found for the requested agent and date range"
+}
+```
+
+### 2. 日趋势查询
+
+```http
+GET /api/v1/recruitment-stats/trend
+```
+
+参数：
+
+| 参数 | 必填 | 说明 |
+|---|---:|---|
+| `agentId` | 是 | 要查询的 Agent |
+| `startDate` | 是 | 开始日期；支持 `YYYY-MM-DD` 或 ISO 时间 |
+| `endDate` | 是 | 结束日期；支持 `YYYY-MM-DD` 或 ISO 时间 |
+| `brandId` | 否 | 品牌整数 ID |
+| `jobNames` | 否 | 岗位名，多选支持重复参数或逗号分隔 |
+
+示例：
+
+```bash
+curl "https://your-domain.com/api/v1/recruitment-stats/trend?agentId=siwen-zhipin-1&startDate=2026-05-01&endDate=2026-05-07&jobNames=肯德基服务员,麦当劳服务员" \
+  -H "Authorization: Bearer $OPEN_API_TOKEN"
+```
+
+返回：
+
+```json
+{
+  "success": true,
+  "data": {
+    "trend": [
+      {
+        "date": "2026-05-01",
+        "messagesReceived": 5,
+        "inboundCandidates": 4,
+        "candidatesReplied": 3,
+        "wechatExchanged": 1,
+        "interviewsBooked": 0,
+        "unreadReplied": 3,
+        "proactiveOutreach": 10,
+        "proactiveResponded": 2
+      }
+    ]
+  }
+}
+```
+
+如果 `agentId + 日期范围` 下没有趋势数据，HTTP 仍返回 `200`，并带明确 `message`：
+
+```json
+{
+  "success": true,
+  "data": {
+    "trend": []
+  },
+  "message": "No recruitment trend data found for the requested agent and date range"
+}
+```
+
+## 指标映射
+
+| API 事件 | 主要影响指标 |
+|---|---|
+| `message_received` | `messagesReceived`, `inboundCandidates`, `proactiveResponded` |
+| `message_sent` | `messagesSent`, `candidatesReplied`, `unreadReplied` |
+| `candidate_contacted` | `proactiveOutreach` |
+| `wechat_exchanged` | `wechatExchanged` |
+| `interview_booked` | `interviewsBooked` |
+| `candidate_hired` | `candidatesHired` |
+
+## 边界条件
+
+| 条件 | 规则 |
+|---|---|
+| `agentId` | 必须属于当前 API key 的 `allowedAgentIds` |
+| `eventTime` | 不能晚于服务端当前时间 5 分钟，不能早于 90 天 |
+| `idempotencyKey` | 建议必填；缺失时不提供请求级幂等 |
+| 批量写入 | 非事务逐条处理，单条失败不回滚其他事件 |
+| 趋势粒度 | 当前只支持日粒度，不支持 `week/month` |
+| `messageSequence` | `message_sent` 使用现有 `MAX(seq)+1` 逻辑；跨请求并发重复序号按现状容忍 |
+
+## 双写约束
+
+同一个 `agentId` 如果正在运行 zhipin 工具自动化，不应再通过 Open API 写同一渠道的 `message_received` / `message_sent`，否则会和工具内部埋点形成双写。Open API 主要用于非工具渠道、第三方回调、企微 bot 或人工后台补录。

--- a/drizzle/0004_odd_spiral.sql
+++ b/drizzle/0004_odd_spiral.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app_huajune"."recruitment_events" ADD COLUMN "idempotency_key" varchar(128);--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_re_idempotency" ON "app_huajune"."recruitment_events" USING btree ("agent_id","idempotency_key") WHERE "app_huajune"."recruitment_events"."idempotency_key" IS NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1057 @@
+{
+  "id": "88c160bb-3f05-47b4-b090-ca5da88e1e21",
+  "prevId": "1893e73f-ab56-49b0-8472-4b0f1925c6f4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app_huajune.data_dictionary": {
+      "name": "data_dictionary",
+      "schema": "app_huajune",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dictionary_type": {
+          "name": "dictionary_type",
+          "type": "dictionary_type",
+          "typeSchema": "app_huajune",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_key": {
+          "name": "mapping_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_value": {
+          "name": "mapping_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dictionary_type": {
+          "name": "idx_dictionary_type",
+          "columns": [
+            {
+              "expression": "dictionary_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_type_key": {
+          "name": "idx_type_key",
+          "columns": [
+            {
+              "expression": "dictionary_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_is_active": {
+          "name": "idx_is_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_type_key": {
+          "name": "unique_active_type_key",
+          "columns": [
+            {
+              "expression": "dictionary_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_huajune\".\"data_dictionary\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_huajune.dictionary_change_log": {
+      "name": "dictionary_change_log",
+      "schema": "app_huajune",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dictionary_id": {
+          "name": "dictionary_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_data": {
+          "name": "old_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_data": {
+          "name": "new_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_reason": {
+          "name": "change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operated_by": {
+          "name": "operated_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operated_at": {
+          "name": "operated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_change_dictionary": {
+          "name": "idx_change_dictionary",
+          "columns": [
+            {
+              "expression": "dictionary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_operated_at": {
+          "name": "idx_change_operated_at",
+          "columns": [
+            {
+              "expression": "operated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_huajune.dictionary_type_definition": {
+      "name": "dictionary_type_definition",
+      "schema": "app_huajune",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type_code": {
+          "name": "type_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dictionary_type_definition_type_code_unique": {
+          "name": "dictionary_type_definition_type_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_huajune.recruitment_agents": {
+      "name": "recruitment_agents",
+      "schema": "app_huajune",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zhipin'"
+        },
+        "primary_brand_id": {
+          "name": "primary_brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_time": {
+          "name": "last_sync_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_huajune.recruitment_daily_stats": {
+      "name": "recruitment_daily_stats",
+      "schema": "app_huajune",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_date": {
+          "name": "stat_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_events": {
+          "name": "total_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_candidates": {
+          "name": "unique_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_sessions": {
+          "name": "unique_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "messages_sent": {
+          "name": "messages_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "messages_received": {
+          "name": "messages_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inbound_candidates": {
+          "name": "inbound_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "candidates_replied": {
+          "name": "candidates_replied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unread_replied": {
+          "name": "unread_replied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "proactive_outreach": {
+          "name": "proactive_outreach",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "proactive_responded": {
+          "name": "proactive_responded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wechat_exchanged": {
+          "name": "wechat_exchanged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interviews_booked": {
+          "name": "interviews_booked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "candidates_hired": {
+          "name": "candidates_hired",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reply_rate": {
+          "name": "reply_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wechat_rate": {
+          "name": "wechat_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interview_rate": {
+          "name": "interview_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dirty": {
+          "name": "is_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aggregated_at": {
+          "name": "aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_daily_stats": {
+          "name": "unique_daily_stats",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stat_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rds_agent": {
+          "name": "idx_rds_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rds_date": {
+          "name": "idx_rds_date",
+          "columns": [
+            {
+              "expression": "stat_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rds_agent_date": {
+          "name": "idx_rds_agent_date",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stat_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rds_dirty": {
+          "name": "idx_rds_dirty",
+          "columns": [
+            {
+              "expression": "is_dirty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_huajune.recruitment_events": {
+      "name": "recruitment_events",
+      "schema": "app_huajune",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_key": {
+          "name": "candidate_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "recruitment_event_type",
+          "typeSchema": "app_huajune",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_name": {
+          "name": "candidate_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_position": {
+          "name": "candidate_position",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_age": {
+          "name": "candidate_age",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_gender": {
+          "name": "candidate_gender",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_education": {
+          "name": "candidate_education",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_expected_salary": {
+          "name": "candidate_expected_salary",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_expected_location": {
+          "name": "candidate_expected_location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_height": {
+          "name": "candidate_height",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_weight": {
+          "name": "candidate_weight",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_health_cert": {
+          "name": "candidate_health_cert",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_details": {
+          "name": "event_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'zhipin'"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_unread_before_reply": {
+          "name": "was_unread_before_reply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count_before_reply": {
+          "name": "unread_count_before_reply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "message_sequence": {
+          "name": "message_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tool_auto'"
+        },
+        "api_source": {
+          "name": "api_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_re_agent": {
+          "name": "idx_re_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_re_time": {
+          "name": "idx_re_time",
+          "columns": [
+            {
+              "expression": "event_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_re_type": {
+          "name": "idx_re_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_re_candidate": {
+          "name": "idx_re_candidate",
+          "columns": [
+            {
+              "expression": "candidate_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_re_session": {
+          "name": "idx_re_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_re_agent_type_time": {
+          "name": "idx_re_agent_type_time",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_re_idempotency": {
+          "name": "unique_re_idempotency",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app_huajune\".\"recruitment_events\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app_huajune.dictionary_type": {
+      "name": "dictionary_type",
+      "schema": "app_huajune",
+      "values": [
+        "brand",
+        "region",
+        "education",
+        "position",
+        "other"
+      ]
+    },
+    "app_huajune.recruitment_event_type": {
+      "name": "recruitment_event_type",
+      "schema": "app_huajune",
+      "values": [
+        "candidate_contacted",
+        "message_sent",
+        "message_received",
+        "wechat_exchanged",
+        "interview_booked",
+        "candidate_hired"
+      ]
+    }
+  },
+  "schemas": {
+    "app_huajune": "app_huajune"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1765521433368,
       "tag": "0003_modern_ma_gnuci",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778123323352,
+      "tag": "0004_odd_spiral",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/services/recruitment-event/__tests__/open-api.test.ts
+++ b/lib/services/recruitment-event/__tests__/open-api.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RecruitmentEventType } from "@/db/types";
 import type { DrizzleInsertEvent, DrizzleSelectEvent } from "../repository";
 
@@ -69,6 +69,10 @@ describe("processOpenApiRecruitmentEvents", () => {
     mockInsertStrict.mockImplementation(async (event: DrizzleInsertEvent) =>
       selectFromInsert(event, `event-${event.idempotencyKey ?? "no-key"}`)
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("rejects unauthorized agentId per item", async () => {

--- a/lib/services/recruitment-event/__tests__/open-api.test.ts
+++ b/lib/services/recruitment-event/__tests__/open-api.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RecruitmentEventType } from "@/db/types";
+import type { DrizzleInsertEvent, DrizzleSelectEvent } from "../repository";
+
+const mockFindByIdempotencyKey = vi.fn();
+const mockInsertStrict = vi.fn();
+const mockGetMaxMessageSequence = vi.fn();
+const mockMarkDirtyBatch = vi.fn();
+const mockExtractBrandIdFromJobName = vi.fn();
+
+vi.mock("../repository", () => ({
+  recruitmentEventsRepository: {
+    findByIdempotencyKey: mockFindByIdempotencyKey,
+    insertStrict: mockInsertStrict,
+    getMaxMessageSequence: mockGetMaxMessageSequence,
+  },
+}));
+
+vi.mock("@/lib/services/recruitment-stats", () => ({
+  recruitmentStatsRepository: {
+    markDirtyBatch: mockMarkDirtyBatch,
+  },
+}));
+
+vi.mock("../brand-lookup", () => ({
+  extractBrandIdFromJobName: mockExtractBrandIdFromJobName,
+}));
+
+function selectFromInsert(event: DrizzleInsertEvent, id: string): DrizzleSelectEvent {
+  return {
+    id,
+    agentId: event.agentId,
+    candidateKey: event.candidateKey,
+    sessionId: event.sessionId ?? null,
+    eventType: event.eventType,
+    eventTime: event.eventTime,
+    candidateName: event.candidateName ?? null,
+    candidatePosition: event.candidatePosition ?? null,
+    candidateAge: event.candidateAge ?? null,
+    candidateGender: event.candidateGender ?? null,
+    candidateEducation: event.candidateEducation ?? null,
+    candidateExpectedSalary: event.candidateExpectedSalary ?? null,
+    candidateExpectedLocation: event.candidateExpectedLocation ?? null,
+    candidateHeight: event.candidateHeight ?? null,
+    candidateWeight: event.candidateWeight ?? null,
+    candidateHealthCert: event.candidateHealthCert ?? null,
+    eventDetails: event.eventDetails ?? null,
+    sourcePlatform: event.sourcePlatform ?? null,
+    jobId: event.jobId ?? null,
+    jobName: event.jobName ?? null,
+    brandId: event.brandId ?? null,
+    wasUnreadBeforeReply: event.wasUnreadBeforeReply ?? null,
+    unreadCountBeforeReply: event.unreadCountBeforeReply ?? 0,
+    messageSequence: event.messageSequence ?? null,
+    createdAt: new Date("2026-05-07T02:00:00Z"),
+    dataSource: event.dataSource ?? null,
+    apiSource: event.apiSource ?? null,
+    idempotencyKey: event.idempotencyKey ?? null,
+  };
+}
+
+describe("processOpenApiRecruitmentEvents", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T02:00:00Z"));
+    vi.clearAllMocks();
+    mockGetMaxMessageSequence.mockResolvedValue(0);
+    mockExtractBrandIdFromJobName.mockResolvedValue(88);
+    mockInsertStrict.mockImplementation(async (event: DrizzleInsertEvent) =>
+      selectFromInsert(event, `event-${event.idempotencyKey ?? "no-key"}`)
+    );
+  });
+
+  it("rejects unauthorized agentId per item", async () => {
+    const { processOpenApiRecruitmentEvents } = await import("../open-api");
+
+    const result = await processOpenApiRecruitmentEvents(
+      [
+        {
+          idempotencyKey: "evt-1",
+          agentId: "zhipin-2",
+          eventType: RecruitmentEventType.CANDIDATE_CONTACTED,
+          eventTime: "2026-05-07T10:00:00+08:00",
+          candidate: { name: "张三" },
+          job: { jobName: "肯德基服务员" },
+        },
+      ],
+      ["zhipin-1"]
+    );
+
+    expect(result.results[0]).toMatchObject({
+      status: "error",
+      error: { code: "ForbiddenAgent" },
+    });
+    expect(mockInsertStrict).not.toHaveBeenCalled();
+    expect(mockExtractBrandIdFromJobName).not.toHaveBeenCalled();
+  });
+
+  it("returns existing when idempotencyKey already exists", async () => {
+    const { processOpenApiRecruitmentEvents } = await import("../open-api");
+    const existing = selectFromInsert(
+      {
+        agentId: "zhipin-1",
+        candidateKey: "zhipin_张三",
+        eventType: "candidate_contacted",
+        eventTime: new Date("2026-05-07T02:00:00Z"),
+        idempotencyKey: "evt-existing",
+      },
+      "event-existing"
+    );
+    mockFindByIdempotencyKey.mockResolvedValueOnce(existing);
+
+    const result = await processOpenApiRecruitmentEvents(
+      [
+        {
+          idempotencyKey: "evt-existing",
+          agentId: "zhipin-1",
+          eventType: RecruitmentEventType.CANDIDATE_CONTACTED,
+          eventTime: "2026-05-07T10:00:00+08:00",
+          candidate: { name: "张三" },
+        },
+      ],
+      ["zhipin-1"]
+    );
+
+    expect(result.results[0]).toMatchObject({
+      status: "existing",
+      eventId: "event-existing",
+      agentId: "zhipin-1",
+      eventType: RecruitmentEventType.CANDIDATE_CONTACTED,
+      eventTime: "2026-05-07T02:00:00.000Z",
+      candidateName: null,
+    });
+    expect(mockInsertStrict).not.toHaveBeenCalled();
+    expect(mockMarkDirtyBatch).toHaveBeenCalledWith([]);
+  });
+
+  it("deduplicates brand lookup and dirty records for batch writes", async () => {
+    const { processOpenApiRecruitmentEvents } = await import("../open-api");
+
+    const result = await processOpenApiRecruitmentEvents(
+      [
+        {
+          idempotencyKey: "evt-1",
+          agentId: "zhipin-1",
+          eventType: RecruitmentEventType.MESSAGE_SENT,
+          eventTime: "2026-05-07T10:00:00+08:00",
+          candidate: { name: "张三" },
+          job: { jobId: 7, jobName: "肯德基服务员" },
+          details: { content: "您好", unreadCountBeforeReply: 1 },
+        },
+        {
+          idempotencyKey: "evt-2",
+          agentId: "zhipin-1",
+          eventType: RecruitmentEventType.MESSAGE_SENT,
+          eventTime: "2026-05-07T10:01:00+08:00",
+          candidate: { name: "李四" },
+          job: { jobId: 7, jobName: "肯德基服务员" },
+          details: { content: "您好", unreadCountBeforeReply: 0 },
+        },
+      ],
+      ["zhipin-1"]
+    );
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every(item => item.status === "created")).toBe(true);
+    expect(result.results[0]).toMatchObject({
+      status: "created",
+      agentId: "zhipin-1",
+      eventType: RecruitmentEventType.MESSAGE_SENT,
+      eventTime: "2026-05-07T02:00:00.000Z",
+      candidateName: "张三",
+      jobId: 7,
+      jobName: "肯德基服务员",
+      apiSource: "open_api",
+      dataSource: "api_callback",
+    });
+    expect(mockExtractBrandIdFromJobName).toHaveBeenCalledTimes(1);
+    expect(mockExtractBrandIdFromJobName).toHaveBeenCalledWith("肯德基服务员");
+
+    const dirtyRecords = mockMarkDirtyBatch.mock.calls[0][0] as Array<{
+      agentId: string;
+      brandId: number | null;
+      jobId: number | null;
+    }>;
+    expect(dirtyRecords).toEqual([
+      expect.objectContaining({ agentId: "zhipin-1", brandId: null, jobId: null }),
+      expect.objectContaining({ agentId: "zhipin-1", brandId: 88, jobId: 7 }),
+      expect.objectContaining({ agentId: "zhipin-1", brandId: null, jobId: null }),
+      expect.objectContaining({ agentId: "zhipin-1", brandId: 88, jobId: 7 }),
+    ]);
+  });
+
+  it("continues writing when brand lookup fails", async () => {
+    const { processOpenApiRecruitmentEvents } = await import("../open-api");
+    mockExtractBrandIdFromJobName.mockRejectedValueOnce(new Error("lookup unavailable"));
+
+    const result = await processOpenApiRecruitmentEvents(
+      [
+        {
+          idempotencyKey: "evt-brand-fail",
+          agentId: "zhipin-1",
+          eventType: RecruitmentEventType.CANDIDATE_CONTACTED,
+          eventTime: "2026-05-07T10:00:00+08:00",
+          candidate: { name: "张三" },
+          job: { jobId: 7, jobName: "未知品牌服务员" },
+        },
+      ],
+      ["zhipin-1"]
+    );
+
+    expect(result.results[0]).toMatchObject({ status: "created" });
+    expect(mockInsertStrict).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: "evt-brand-fail",
+        brandId: undefined,
+      })
+    );
+  });
+
+  it("rejects eventTime outside allowed range", async () => {
+    const { processOpenApiRecruitmentEvents } = await import("../open-api");
+
+    const result = await processOpenApiRecruitmentEvents(
+      [
+        {
+          idempotencyKey: "evt-future",
+          agentId: "zhipin-1",
+          eventType: RecruitmentEventType.CANDIDATE_CONTACTED,
+          eventTime: "2026-05-07T10:06:00+08:00",
+          candidate: { name: "张三" },
+          job: { jobName: "肯德基服务员" },
+        },
+      ],
+      ["zhipin-1"]
+    );
+
+    expect(result.results[0]).toMatchObject({
+      status: "error",
+      error: { code: "InvalidEventTime" },
+    });
+    expect(mockInsertStrict).not.toHaveBeenCalled();
+    expect(mockExtractBrandIdFromJobName).not.toHaveBeenCalled();
+  });
+});

--- a/lib/services/recruitment-event/__tests__/service.test.ts
+++ b/lib/services/recruitment-event/__tests__/service.test.ts
@@ -101,6 +101,7 @@ describe("RecruitmentEventService", () => {
     createdAt: new Date(),
     dataSource: mockEvent.dataSource ?? null,
     apiSource: mockEvent.apiSource ?? null,
+    idempotencyKey: null,
   };
 
   beforeEach(() => {

--- a/lib/services/recruitment-event/builder.ts
+++ b/lib/services/recruitment-event/builder.ts
@@ -23,6 +23,7 @@ import {
   type SourcePlatformValue,
   type EventDetails,
   type WechatExchangeTypeValue,
+  type DataSourceValue,
 } from "@/db/types";
 import { recruitmentContext } from "./context";
 import type { DrizzleInsertEvent } from "./repository";
@@ -156,6 +157,24 @@ export class RecruitmentEventBuilder {
   }
 
   /**
+   * Override data source.
+   *
+   * Open API writes use api_callback/manual, while tool-triggered events keep tool_auto.
+   */
+  withDataSource(dataSource: DataSourceValue): this {
+    this.data.dataSource = dataSource;
+    return this;
+  }
+
+  /**
+   * Set request idempotency key for Open API writes.
+   */
+  withIdempotencyKey(idempotencyKey?: string): this {
+    this.data.idempotencyKey = idempotencyKey;
+    return this;
+  }
+
+  /**
    * Create a MESSAGE_SENT event
    *
    * @param content - Message content
@@ -277,11 +296,17 @@ export class RecruitmentEventBuilder {
     eventDetails: EventDetails;
   }): DrizzleInsertEvent {
     const eventTime = this.data.eventTime || new Date();
+    const sourcePlatform = this.data.sourcePlatform;
+    const agentId = this.data.agentId;
+
+    if (!sourcePlatform || !agentId) {
+      throw new Error("[RecruitmentEventBuilder] Missing required context fields");
+    }
 
     // Generate candidateKey
     // Use this.data.sourcePlatform which may be overridden by forPlatform()
     const candidateKey = generateCandidateKey({
-      platform: this.data.sourcePlatform!,
+      platform: sourcePlatform,
       candidateName: this.data.candidateName || "unknown",
       candidatePosition: this.data.candidatePosition ?? undefined,
     });
@@ -290,7 +315,7 @@ export class RecruitmentEventBuilder {
     const sessionId = generateSessionId(this.context.agentId, candidateKey, eventTime);
 
     return {
-      agentId: this.data.agentId!,
+      agentId,
       candidateKey,
       sessionId,
       eventType: eventData.eventType,
@@ -315,6 +340,7 @@ export class RecruitmentEventBuilder {
       messageSequence: this.data.messageSequence,
       dataSource: this.data.dataSource,
       apiSource: this.data.apiSource,
+      idempotencyKey: this.data.idempotencyKey,
     };
   }
 }

--- a/lib/services/recruitment-event/open-api.ts
+++ b/lib/services/recruitment-event/open-api.ts
@@ -1,0 +1,476 @@
+import { z } from "zod/v3";
+import {
+  ApiSource,
+  DataSource,
+  RecruitmentEventType,
+  SourcePlatform,
+  WechatExchangeType,
+  type DataSourceValue,
+  type SourcePlatformValue,
+  type WechatExchangeTypeValue,
+} from "@/db/types";
+import { extractBrandIdFromJobName } from "./brand-lookup";
+import { parseAge, parseSalary } from "./candidate-parser";
+import { recruitmentEventService } from "./service";
+import { recruitmentEventsRepository, type DrizzleInsertEvent, type DrizzleSelectEvent } from "./repository";
+import { recruitmentStatsRepository } from "@/lib/services/recruitment-stats";
+import { isAgentAllowed } from "@/lib/utils/open-api-agent-auth";
+import type { DirtyRecord } from "@/lib/services/recruitment-stats/types";
+import type { RecruitmentContext } from "./types";
+
+const MAX_BATCH_SIZE = 100;
+const MAX_FUTURE_MS = 5 * 60 * 1000;
+const MAX_PAST_MS = 90 * 24 * 60 * 60 * 1000;
+
+const candidateSchema = z.object({
+  name: z.string().min(1).max(100),
+  position: z.string().max(100).optional(),
+  age: z.string().max(20).optional(),
+  gender: z.string().max(10).optional(),
+  education: z.string().max(50).optional(),
+  expectedSalary: z.string().max(50).optional(),
+  expectedLocation: z.string().max(100).optional(),
+  height: z.string().max(20).optional(),
+  weight: z.string().max(20).optional(),
+  healthCert: z.boolean().optional(),
+});
+
+const jobSchema = z.object({
+  jobId: z.number().int().optional(),
+  jobName: z.string().max(100).optional(),
+});
+
+const baseEventSchema = z.object({
+  idempotencyKey: z.string().min(1).max(128).optional(),
+  agentId: z.string().min(1).max(50),
+  sourcePlatform: z
+    .enum([SourcePlatform.ZHIPIN, SourcePlatform.YUPAO, SourcePlatform.DULIDAY])
+    .default(SourcePlatform.ZHIPIN),
+  dataSource: z.enum([DataSource.API_CALLBACK, DataSource.MANUAL]).default(DataSource.API_CALLBACK),
+  eventTime: z.string().optional(),
+  candidate: candidateSchema,
+  job: jobSchema.optional(),
+  brandId: z.number().int().optional(),
+});
+
+const openApiEventSchema = z.discriminatedUnion("eventType", [
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.MESSAGE_SENT),
+    details: z.object({
+      content: z.string().min(1),
+      isAutoReply: z.boolean().optional(),
+      unreadCountBeforeReply: z.number().int().min(0).optional(),
+    }),
+  }),
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.MESSAGE_RECEIVED),
+    details: z.object({
+      unreadCount: z.number().int().min(0).optional(),
+      lastMessagePreview: z.string().optional(),
+    }).optional().default({}),
+  }),
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.WECHAT_EXCHANGED),
+    details: z.object({
+      wechatNumber: z.string().optional(),
+      exchangeType: z
+        .enum([
+          WechatExchangeType.REQUESTED,
+          WechatExchangeType.ACCEPTED,
+          WechatExchangeType.COMPLETED,
+        ])
+        .optional(),
+    }).optional().default({}),
+  }),
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.INTERVIEW_BOOKED),
+    details: z.object({
+      interviewTime: z.string().min(1),
+      address: z.string().optional(),
+      candidatePhone: z.string().optional(),
+    }),
+  }),
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.CANDIDATE_CONTACTED),
+    details: z.object({}).optional().default({}),
+  }),
+  baseEventSchema.extend({
+    eventType: z.literal(RecruitmentEventType.CANDIDATE_HIRED),
+    details: z.object({
+      hireDate: z.string().optional(),
+      notes: z.string().optional(),
+    }).optional().default({}),
+  }),
+]);
+
+const openApiBatchSchema = z.object({
+  events: z.array(z.unknown()).min(1).max(MAX_BATCH_SIZE),
+});
+
+export type OpenApiRecruitmentEventInput = z.infer<typeof openApiEventSchema>;
+
+export type OpenApiRecruitmentEventResult =
+  | {
+      idempotencyKey?: string;
+      status: "created" | "existing";
+      eventId: string;
+      agentId: string;
+      eventType: string;
+      eventTime: string;
+      candidateKey: string;
+      candidateName: string | null;
+      sessionId: string | null;
+      sourcePlatform: string | null;
+      jobId: number | null;
+      jobName: string | null;
+      apiSource: string | null;
+      dataSource: string | null;
+    }
+  | {
+      idempotencyKey?: string;
+      status: "error";
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+
+export interface ProcessOpenApiRecruitmentEventsResult {
+  results: OpenApiRecruitmentEventResult[];
+}
+
+type ParsedItem =
+  | { index: number; success: true; event: OpenApiRecruitmentEventInput }
+  | { index: number; success: false; idempotencyKey?: string; code: string; message: string };
+
+export function parseOpenApiRecruitmentEventsBody(body: unknown): unknown[] {
+  return openApiBatchSchema.parse(body).events;
+}
+
+export async function processOpenApiRecruitmentEvents(
+  rawEvents: unknown[],
+  allowedAgentIds: readonly string[]
+): Promise<ProcessOpenApiRecruitmentEventsResult> {
+  const parsedItems = rawEvents.map(parseItem);
+  const brandMap = await resolveBrandIds(parsedItems, allowedAgentIds);
+  const results = new Array<OpenApiRecruitmentEventResult>(rawEvents.length);
+  const dirtyRecords: DirtyRecord[] = [];
+
+  for (const item of parsedItems) {
+    if (!item.success) {
+      results[item.index] = errorResult(item.idempotencyKey, item.code, item.message);
+      continue;
+    }
+
+    const result = await processOneEvent(item.event, allowedAgentIds, brandMap);
+    results[item.index] = result.result;
+    if (result.inserted) {
+      dirtyRecords.push(...buildDirtyRecords(result.inserted));
+    }
+  }
+
+  await recruitmentStatsRepository.markDirtyBatch(dirtyRecords);
+
+  return { results };
+}
+
+function parseItem(raw: unknown, index: number): ParsedItem {
+  const idempotencyKey = extractIdempotencyKey(raw);
+  const parsed = openApiEventSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      index,
+      success: false,
+      idempotencyKey,
+      code: "InvalidEvent",
+      message: parsed.error.issues.map(issue => issue.message).join("; "),
+    };
+  }
+
+  return { index, success: true, event: parsed.data };
+}
+
+function extractIdempotencyKey(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object" || !("idempotencyKey" in raw)) return undefined;
+  const value = (raw as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof value === "string" ? value : undefined;
+}
+
+async function resolveBrandIds(
+  parsedItems: ParsedItem[],
+  allowedAgentIds: readonly string[]
+): Promise<Map<string, number | undefined>> {
+  const jobNames = new Set<string>();
+
+  for (const item of parsedItems) {
+    if (
+      item.success &&
+      isAgentAllowed(item.event.agentId, allowedAgentIds) &&
+      parseAndValidateEventTime(item.event.eventTime).valid &&
+      item.event.brandId === undefined &&
+      item.event.job?.jobName
+    ) {
+      jobNames.add(item.event.job.jobName);
+    }
+  }
+
+  const entries = await Promise.all(
+    Array.from(jobNames).map(async jobName => {
+      try {
+        return [jobName, await extractBrandIdFromJobName(jobName)] as const;
+      } catch (error) {
+        console.warn("[RecruitmentEvent][OpenAPI] Brand lookup failed:", {
+          jobName,
+          error,
+        });
+        return [jobName, undefined] as const;
+      }
+    })
+  );
+
+  return new Map(entries);
+}
+
+async function processOneEvent(
+  event: OpenApiRecruitmentEventInput,
+  allowedAgentIds: readonly string[],
+  brandMap: ReadonlyMap<string, number | undefined>
+): Promise<{ result: OpenApiRecruitmentEventResult; inserted?: DrizzleSelectEvent }> {
+  if (!isAgentAllowed(event.agentId, allowedAgentIds)) {
+    return {
+      result: errorResult(
+        event.idempotencyKey,
+        "ForbiddenAgent",
+        `Agent '${event.agentId}' is not authorized for this API key`
+      ),
+    };
+  }
+
+  const eventTime = parseAndValidateEventTime(event.eventTime);
+  if (!eventTime.valid) {
+    return {
+      result: errorResult(event.idempotencyKey, eventTime.code, eventTime.message),
+    };
+  }
+
+  if (event.idempotencyKey) {
+    const existing = await recruitmentEventsRepository.findByIdempotencyKey(
+      event.agentId,
+      event.idempotencyKey
+    );
+    if (existing) {
+      return { result: existingResult(existing) };
+    }
+  }
+
+  const insertEvent = await buildInsertEvent(event, eventTime.value, brandMap);
+
+  try {
+    const inserted = await recruitmentEventsRepository.insertStrict(insertEvent);
+    return { result: createdResult(inserted), inserted };
+  } catch (error) {
+    if (event.idempotencyKey && isUniqueViolation(error)) {
+      const existing = await recruitmentEventsRepository.findByIdempotencyKey(
+        event.agentId,
+        event.idempotencyKey
+      );
+      if (existing) {
+        return { result: existingResult(existing) };
+      }
+    }
+
+    console.error("[RecruitmentEvent][OpenAPI] Insert failed:", error);
+
+    return {
+      result: errorResult(
+        event.idempotencyKey,
+        "InsertFailed",
+        "Failed to insert recruitment event"
+      ),
+    };
+  }
+}
+
+async function buildInsertEvent(
+  input: OpenApiRecruitmentEventInput,
+  eventTime: Date,
+  brandMap: ReadonlyMap<string, number | undefined>
+): Promise<DrizzleInsertEvent> {
+  const jobName = input.job?.jobName;
+  const brandId = input.brandId ?? (jobName ? brandMap.get(jobName) : undefined);
+  const candidatePosition = input.candidate.position ?? jobName;
+  const context: RecruitmentContext = {
+    agentId: input.agentId,
+    sourcePlatform: input.sourcePlatform as SourcePlatformValue,
+    apiSource: ApiSource.OPEN_API,
+    brandId,
+    jobId: input.job?.jobId,
+    jobName,
+  };
+
+  const builder = recruitmentEventService
+    .event(context)
+    .withDataSource(input.dataSource as DataSourceValue)
+    .withIdempotencyKey(input.idempotencyKey)
+    .candidate({
+      name: input.candidate.name,
+      position: candidatePosition,
+      age: parseAge(input.candidate.age),
+      gender: input.candidate.gender,
+      education: input.candidate.education,
+      expectedSalary: parseSalary(input.candidate.expectedSalary),
+      expectedLocation: input.candidate.expectedLocation,
+      height: input.candidate.height,
+      weight: input.candidate.weight,
+      healthCert: input.candidate.healthCert,
+    })
+    .at(eventTime);
+
+  if (input.job?.jobName) {
+    builder.forJob(input.job.jobId ?? 0, input.job.jobName);
+  }
+  if (brandId) {
+    builder.forBrand(brandId);
+  }
+
+  switch (input.eventType) {
+    case "message_sent": {
+      builder.withUnreadContext(input.details.unreadCountBeforeReply ?? 0);
+      const probe = builder.messageSent(input.details.content, {
+        isAutoReply: input.details.isAutoReply,
+      });
+      const messageSequence = await recruitmentEventService.getNextMessageSequence(
+        probe.sessionId ?? ""
+      );
+      return {
+        ...probe,
+        messageSequence,
+      };
+    }
+    case "message_received":
+      builder.withUnreadContext(input.details.unreadCount ?? 0);
+      return builder.messageReceived(input.details.unreadCount ?? 0, input.details.lastMessagePreview);
+    case "wechat_exchanged":
+      return builder.wechatExchanged(
+        input.details.wechatNumber,
+        input.details.exchangeType as WechatExchangeTypeValue | undefined
+      );
+    case "interview_booked":
+      return builder.interviewBooked({
+        interviewTime: input.details.interviewTime,
+        address: input.details.address,
+        candidatePhone: input.details.candidatePhone,
+      });
+    case "candidate_contacted":
+      return builder.candidateContacted();
+    case "candidate_hired":
+      return builder.candidateHired(input.details.hireDate, input.details.notes);
+  }
+}
+
+function parseAndValidateEventTime(
+  eventTime?: string
+):
+  | { valid: true; value: Date }
+  | { valid: false; code: "InvalidEventTime"; message: string } {
+  const parsed = eventTime ? new Date(eventTime) : new Date();
+
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      valid: false,
+      code: "InvalidEventTime",
+      message: "eventTime must be a valid date string",
+    };
+  }
+
+  const now = Date.now();
+  if (parsed.getTime() > now + MAX_FUTURE_MS) {
+    return {
+      valid: false,
+      code: "InvalidEventTime",
+      message: "eventTime cannot be more than 5 minutes in the future",
+    };
+  }
+  if (parsed.getTime() < now - MAX_PAST_MS) {
+    return {
+      valid: false,
+      code: "InvalidEventTime",
+      message: "eventTime cannot be older than 90 days",
+    };
+  }
+
+  return { valid: true, value: parsed };
+}
+
+function buildDirtyRecords(event: DrizzleSelectEvent): DirtyRecord[] {
+  const records: DirtyRecord[] = [
+    {
+      agentId: event.agentId,
+      statDate: event.eventTime,
+      brandId: null,
+      jobId: null,
+    },
+  ];
+
+  if (event.brandId !== null || event.jobId !== null) {
+    records.push({
+      agentId: event.agentId,
+      statDate: event.eventTime,
+      brandId: event.brandId,
+      jobId: event.jobId,
+    });
+  }
+
+  return records;
+}
+
+function createdResult(event: DrizzleSelectEvent): OpenApiRecruitmentEventResult {
+  return eventResult(event, "created");
+}
+
+function existingResult(event: DrizzleSelectEvent): OpenApiRecruitmentEventResult {
+  return eventResult(event, "existing");
+}
+
+function eventResult(
+  event: DrizzleSelectEvent,
+  status: "created" | "existing"
+): OpenApiRecruitmentEventResult {
+  return {
+    idempotencyKey: event.idempotencyKey ?? undefined,
+    status,
+    eventId: event.id,
+    agentId: event.agentId,
+    eventType: event.eventType,
+    eventTime: event.eventTime.toISOString(),
+    candidateKey: event.candidateKey,
+    candidateName: event.candidateName,
+    sessionId: event.sessionId,
+    sourcePlatform: event.sourcePlatform,
+    jobId: event.jobId,
+    jobName: event.jobName,
+    apiSource: event.apiSource,
+    dataSource: event.dataSource,
+  };
+}
+
+function errorResult(
+  idempotencyKey: string | undefined,
+  code: string,
+  message: string
+): OpenApiRecruitmentEventResult {
+  return {
+    idempotencyKey,
+    status: "error",
+    error: { code, message },
+  };
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "23505"
+  );
+}

--- a/lib/services/recruitment-event/repository.ts
+++ b/lib/services/recruitment-event/repository.ts
@@ -67,7 +67,11 @@ class RecruitmentEventsRepository {
    * @param event - The event to insert
    * @returns The inserted event or null if failed
    */
-  async insert(event: DrizzleInsertEvent): Promise<DrizzleSelectEvent | null> {
+  async insert(
+    event: DrizzleInsertEvent,
+    options: { markDirty?: boolean } = {}
+  ): Promise<DrizzleSelectEvent | null> {
+    const { markDirty = true } = options;
     const result = await withRetry(async () => {
       const db = getDb();
       const [inserted] = await db.insert(recruitmentEvents).values(event).returning();
@@ -76,7 +80,7 @@ class RecruitmentEventsRepository {
     }, "insert");
 
     // 标记统计数据为脏（需要重新聚合）
-    if (result) {
+    if (result && markDirty) {
       // 1. 始终标记汇总行（brand_id: null, job_id: null）为脏
       recruitmentStatsRepository
         .markDirty(result.agentId, result.eventTime, null, null)
@@ -100,6 +104,46 @@ class RecruitmentEventsRepository {
     }
 
     return result;
+  }
+
+  /**
+   * Insert a single recruitment event and let database errors bubble up.
+   *
+   * Used by Open API idempotent writes so unique-violation races can be
+   * translated to an "existing" result instead of being swallowed by retry.
+   */
+  async insertStrict(event: DrizzleInsertEvent): Promise<DrizzleSelectEvent> {
+    const db = getDb();
+    const [inserted] = await db.insert(recruitmentEvents).values(event).returning();
+    if (!inserted) {
+      throw new Error("Recruitment event insert returned no row");
+    }
+    console.log(`${LOG_PREFIX} Event inserted: ${inserted.id} (${inserted.eventType})`);
+    return inserted;
+  }
+
+  /**
+   * Find an event by Open API idempotency key.
+   */
+  async findByIdempotencyKey(
+    agentId: string,
+    idempotencyKey: string
+  ): Promise<DrizzleSelectEvent | null> {
+    const result = await withRetry(async () => {
+      const db = getDb();
+      return db
+        .select()
+        .from(recruitmentEvents)
+        .where(
+          and(
+            eq(recruitmentEvents.agentId, agentId),
+            eq(recruitmentEvents.idempotencyKey, idempotencyKey)
+          )
+        )
+        .limit(1);
+    }, "findByIdempotencyKey");
+
+    return result?.[0] ?? null;
   }
 
   /**

--- a/lib/services/recruitment-stats/repository.ts
+++ b/lib/services/recruitment-stats/repository.ts
@@ -153,6 +153,38 @@ class RecruitmentStatsRepository {
   }
 
   /**
+   * Mark multiple dirty dimensions after a batch event insert.
+   *
+   * The caller may pass duplicate records; this method normalizes and de-dupes
+   * by agent/date/brand/job before issuing upserts.
+   */
+  async markDirtyBatch(records: DirtyRecord[]): Promise<void> {
+    const uniqueRecords = new Map<string, DirtyRecord>();
+
+    for (const record of records) {
+      const statDate = toBeijingMidnight(record.statDate);
+      const key = [
+        record.agentId,
+        statDate.toISOString(),
+        record.brandId ?? "null",
+        record.jobId ?? "null",
+      ].join("|");
+      uniqueRecords.set(key, {
+        agentId: record.agentId,
+        statDate,
+        brandId: record.brandId ?? null,
+        jobId: record.jobId ?? null,
+      });
+    }
+
+    await Promise.all(
+      Array.from(uniqueRecords.values()).map(record =>
+        this.markDirty(record.agentId, record.statDate, record.brandId, record.jobId)
+      )
+    );
+  }
+
+  /**
    * 更新/插入聚合统计
    *
    * 使用 PostgreSQL ON CONFLICT DO UPDATE 实现原子 upsert

--- a/lib/utils/open-api-agent-auth.ts
+++ b/lib/utils/open-api-agent-auth.ts
@@ -1,0 +1,28 @@
+import { ApiErrorType, createErrorResponse } from "@/lib/utils/api-response";
+
+const ALLOWED_AGENT_IDS_HEADER = "x-open-api-allowed-agent-ids";
+
+export function getAllowedAgentIds(request: Request): string[] {
+  const raw = request.headers.get(ALLOWED_AGENT_IDS_HEADER);
+  if (!raw) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string" && item.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export function isAgentAllowed(agentId: string, allowedAgentIds: readonly string[]): boolean {
+  return allowedAgentIds.includes("*") || allowedAgentIds.includes(agentId);
+}
+
+export function createAgentForbiddenResponse(agentId: string, correlationId?: string) {
+  return createErrorResponse(ApiErrorType.Forbidden, {
+    message: `Agent '${agentId}' is not authorized for this API key`,
+    details: { agentId },
+    correlationId,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.30.1",
+  "version": "1.31.0-develop.1",
   "private": true,
   "main": "build/main.js",
   "scripts": {

--- a/proxy.ts
+++ b/proxy.ts
@@ -66,7 +66,12 @@ const AUTH_SERVICE_TIMEOUT = 5000; // 5秒超时
  * Token 缓存配置
  */
 const TOKEN_CACHE_TTL = 60_000; // 60秒缓存
-const tokenCache = new Map<string, number>(); // token -> expiresAt (ms)
+interface CachedTokenAuth {
+  expiresAt: number;
+  allowedAgentIds: string[];
+}
+
+const tokenCache = new Map<string, CachedTokenAuth>(); // token -> auth context
 
 // 导出清理缓存的函数（仅用于测试）
 export const clearTokenCache = () => {
@@ -78,8 +83,8 @@ export const clearTokenCache = () => {
  */
 function cleanupExpiredCache() {
   const now = Date.now();
-  for (const [token, expiresAt] of tokenCache.entries()) {
-    if (expiresAt <= now) {
+  for (const [token, auth] of tokenCache.entries()) {
+    if (auth.expiresAt <= now) {
       tokenCache.delete(token);
     }
   }
@@ -98,14 +103,14 @@ if (typeof globalThis !== "undefined" && !_globalCache.__cacheCleanupInterval) {
  * @param authorization Authorization header 值
  * @returns 是否验证通过
  */
-async function validateOpenApiToken(authorization: string): Promise<boolean> {
+async function validateOpenApiToken(authorization: string): Promise<string[] | null> {
   const now = Date.now();
 
   // 1. 检查缓存
-  const cachedExpiry = tokenCache.get(authorization);
-  if (cachedExpiry && cachedExpiry > now) {
+  const cached = tokenCache.get(authorization);
+  if (cached && cached.expiresAt > now) {
     console.log("[Open API Auth] Token validated from cache");
-    return true;
+    return cached.allowedAgentIds;
   }
 
   // 2. 调用外部鉴权服务
@@ -128,21 +133,31 @@ async function validateOpenApiToken(authorization: string): Promise<boolean> {
       const data = await response.json();
       // 验证成功响应格式 {"isSuccess": true, ...}
       if (data?.isSuccess === true) {
+        const allowedAgentIds = getOpenApiAllowedAgentIds();
         // 写入缓存
-        tokenCache.set(authorization, now + TOKEN_CACHE_TTL);
+        tokenCache.set(authorization, {
+          expiresAt: now + TOKEN_CACHE_TTL,
+          allowedAgentIds,
+        });
         console.log("[Open API Auth] Token validated and cached");
-        return true;
+        return allowedAgentIds;
       }
     }
 
     console.log(`[Open API Auth] Token validation failed: ${response.status}`);
-    return false;
+    return null;
   } catch (error) {
     // 网络错误或超时
     console.error("[Open API Auth] External auth service error:", error);
     // 安全优先：外部服务不可用时拒绝访问
-    return false;
+    return null;
   }
+}
+
+function getOpenApiAllowedAgentIds(): string[] {
+  // 当前外部鉴权服务只负责验证 key 是否有效，不提供业务授权范围。
+  // 为了先跑通 Open API，认证通过后暂时允许访问全部 agentId。
+  return ["*"];
 }
 
 /**
@@ -161,48 +176,56 @@ function createErrorResponse(
  * @param request Next.js 请求对象
  * @returns 如果鉴权失败返回错误响应，成功返回 null
  */
-async function handleOpenApiAuth(request: NextRequest): Promise<NextResponse | null> {
+async function handleOpenApiAuth(
+  request: NextRequest
+): Promise<{ response: NextResponse } | { allowedAgentIds: string[] }> {
   const auth = request.headers.get("authorization");
 
   // 1. 检查 Authorization header
   if (!auth) {
-    return createErrorResponse(
-      {
-        error: "Unauthorized",
-        message: "Missing authorization header",
-        statusCode: 401,
-      },
-      request
-    );
+    return {
+      response: createErrorResponse(
+        {
+          error: "Unauthorized",
+          message: "Missing authorization header",
+          statusCode: 401,
+        },
+        request
+      ),
+    };
   }
 
   // 2. 检查格式（Bearer token）
   if (!auth.startsWith("Bearer ")) {
-    return createErrorResponse(
-      {
-        error: "Unauthorized",
-        message: "Invalid authorization format. Use: Bearer <token>",
-        statusCode: 401,
-      },
-      request
-    );
+    return {
+      response: createErrorResponse(
+        {
+          error: "Unauthorized",
+          message: "Invalid authorization format. Use: Bearer <token>",
+          statusCode: 401,
+        },
+        request
+      ),
+    };
   }
 
   // 3. 验证 Token
-  const isValid = await validateOpenApiToken(auth);
-  if (!isValid) {
-    return createErrorResponse(
-      {
-        error: "Unauthorized",
-        message: "Invalid or expired API key",
-        statusCode: 401,
-      },
-      request
-    );
+  const allowedAgentIds = await validateOpenApiToken(auth);
+  if (!allowedAgentIds) {
+    return {
+      response: createErrorResponse(
+        {
+          error: "Unauthorized",
+          message: "Invalid or expired API key",
+          statusCode: 401,
+        },
+        request
+      ),
+    };
   }
 
   // 鉴权成功
-  return null;
+  return { allowedAgentIds };
 }
 
 // ========== 主 Proxy 函数 ==========
@@ -220,12 +243,21 @@ export async function proxy(request: NextRequest) {
   // 2. 检查是否是 Open API 路径
   if (pathname.startsWith("/api/v1/")) {
     // 对 Open API 路径进行特殊鉴权
-    const authError = await handleOpenApiAuth(request);
-    if (authError) {
-      return authError; // 错误响应已包含 CORS 头
+    const authResult = await handleOpenApiAuth(request);
+    if ("response" in authResult) {
+      return authResult.response; // 错误响应已包含 CORS 头
     }
     // 鉴权成功，继续处理请求，并添加 CORS 头
-    const response = NextResponse.next();
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set(
+      "x-open-api-allowed-agent-ids",
+      JSON.stringify(authResult.allowedAgentIds)
+    );
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
     return addCorsHeaders(response, request);
   }
 


### PR DESCRIPTION
## Summary

- Add Open API recruitment event ingestion via `POST /api/v1/recruitment-events`
- Add recruitment stats query endpoints for `summary` and `trend`
- Add `recruitment_events.idempotency_key` and partial unique index for request-level idempotency
- Update Open API auth behavior to authenticate keys externally while temporarily allowing all `agentId` values
- Document event payloads, query examples, no-data messages, idempotency behavior, and double-write boundaries

## Verification

- `pnpm test:run lib/services/recruitment-event/__tests__/open-api.test.ts app/api/v1/recruitment-stats/__tests__/routes.test.ts __tests__/proxy.test.ts`
- `npx tsc --noEmit`
- `pnpm lint` (`0 errors`, existing warnings remain)
- Applied Drizzle migration with `pnpm db:migrate`
- Manually tested `summary`, `trend`, `created`, and `existing` responses against the live PostgreSQL-backed local API

## Notes

- Current key authorization intentionally does not enforce `key -> agentId` ranges. `proxy.ts` injects `allowedAgentIds=["*"]` after external key authentication so the API can be integrated first.
- Fine-grained key-to-agent authorization should be added later inside this project rather than in the external auth service.
