### PR TITLE
fix: exclude build artifacts from standalone image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,9 @@ npm-debug.log
 README.md
 .next
 .next.cache
+dist
+build
+out
 docker
 .git
 .gitignore
@@ -26,6 +29,12 @@ docker
 # 日志文件
 logs
 *.log
+
+# 构建产物 - 不应该进入 Web Docker 镜像
+*.dmg
+*.exe
+*.zip
+*.blockmap
 
 # 临时文件
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+## [1.31.2-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.31.1...v1.31.2-develop.1) (2026-05-08)
+
+
+### Bug Fixes
+
+* exclude build artifacts from standalone image ([a89655a](https://github.com/steveoon/agent-computer-user/commit/a89655a4b11e3c155c1e66a47d907323e672825b))
+
 ## [1.31.1](https://github.com/steveoon/agent-computer-user/compare/v1.31.0...v1.31.1) (2026-05-08)
 
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,18 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone",
+  outputFileTracingExcludes: {
+    "/*": [
+      "dist/**/*",
+      "build/**/*",
+      "coverage/**/*",
+      "logs/**/*",
+      "*.dmg",
+      "*.exe",
+      "*.zip",
+      "*.blockmap",
+    ],
+  },
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.31.1",
+  "version": "1.31.2-develop.1",
   "private": true,
   "packageManager": "pnpm@10.31.0",
   "main": "build/main.js",


### PR DESCRIPTION
## Summary

- exclude local Electron/build artifacts from Docker build context
- exclude `dist`, `build`, `coverage`, and logs from Next.js standalone output tracing
- prevent Electron `.dmg` / `.app` artifacts from inflating the web Docker image

## Verification

- `pnpm build`
- `pnpm exec eslint next.config.ts`
- `npx tsc --noEmit`

## Notes

The local `.next/standalone` output dropped from about `854MB` to `109MB` while `dist/` still existed locally, confirming that standalone output no longer includes Electron build artifacts.
