### PR TITLE
fix: preserve next runtime in standalone image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+## [1.31.3-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.31.2...v1.31.3-develop.1) (2026-05-08)
+
+
+### Bug Fixes
+
+* preserve next runtime in standalone output ([dbed1e1](https://github.com/steveoon/agent-computer-user/commit/dbed1e1737900db38c78323d05c96f57684f778d))
+
 ## [1.31.2](https://github.com/steveoon/agent-computer-user/compare/v1.31.1...v1.31.2) (2026-05-08)
 
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,18 +3,6 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone",
-  outputFileTracingExcludes: {
-    "/*": [
-      "dist/**/*",
-      "build/**/*",
-      "coverage/**/*",
-      "logs/**/*",
-      "*.dmg",
-      "*.exe",
-      "*.zip",
-      "*.blockmap",
-    ],
-  },
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.31.2",
+  "version": "1.31.3-develop.1",
   "private": true,
   "packageManager": "pnpm@10.31.0",
   "main": "build/main.js",


### PR DESCRIPTION
## Summary

- remove the Next.js `outputFileTracingExcludes` rule that accidentally excluded `node_modules/next/dist/...`
- keep Docker image slimming at the Docker build context layer via `.dockerignore`
- restore the missing `next/dist/compiled/next-server/app-route-turbo.runtime.prod.js` runtime file in standalone output

## Verification

- `pnpm build`
- `pnpm exec eslint next.config.ts`
- `npx tsc --noEmit`
- `docker build --platform linux/amd64 -t ai-computer-use:standalone-fix .`
- `curl -sS -i --max-time 10 http://127.0.0.1:30002/api/health`

## Result

The test Docker image is `244MB` and `/api/health` returns `200 OK`.
