### PR TITLE
fix: skip desktop binary downloads in docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+## [1.31.4-develop.2](https://github.com/steveoon/agent-computer-user/compare/v1.31.4-develop.1...v1.31.4-develop.2) (2026-05-08)
+
+
+### Bug Fixes
+
+* propagate binary skip envs to builder stage ([c7e3110](https://github.com/steveoon/agent-computer-user/commit/c7e3110639b7a197c18b28c7286134256f1aafae))
+
 ## [1.31.4-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.31.3...v1.31.4-develop.1) (2026-05-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to AI SDK Computer Use will be documented in this file.
 
+## [1.31.4-develop.1](https://github.com/steveoon/agent-computer-user/compare/v1.31.3...v1.31.4-develop.1) (2026-05-08)
+
+
+### Bug Fixes
+
+* skip desktop binary downloads in docker build ([5bcdd0a](https://github.com/steveoon/agent-computer-user/commit/5bcdd0a948e3c014ad435a8c0c94354321a9bd98))
+
 ## [1.31.3](https://github.com/steveoon/agent-computer-user/compare/v1.31.2...v1.31.3) (2026-05-08)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN \
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
+# Web Docker images do not need desktop/browser binaries. Keep package postinstall
+# scripts enabled for native web runtime packages such as sharp and esbuild.
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.31.3",
+  "version": "1.31.4-develop.1",
   "private": true,
   "packageManager": "pnpm@10.31.0",
   "main": "build/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-computer-use",
-  "version": "1.31.4-develop.1",
+  "version": "1.31.4-develop.2",
   "private": true,
   "packageManager": "pnpm@10.31.0",
   "main": "build/main.js",


### PR DESCRIPTION
## Summary

- skip Electron binary downloads during Web Docker image dependency installation
- skip Puppeteer browser downloads during Web Docker image dependency installation
- keep native package postinstall scripts enabled for packages such as `sharp` and `esbuild`

## Verification

- `docker build --target deps --platform linux/amd64 -t ai-computer-use:deps-skip-electron .`

## Result

The Docker `deps` stage now completes with:

- `electron postinstall: Done`
- `puppeteer postinstall: Skipping downloading browsers as instructed`
- `sharp install: Done`
- `esbuild postinstall: Done`
